### PR TITLE
backporting v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The ZPR ZPL Compiler Changelog
 
+## [0.2.0] - 2025-05-01
+
+- Support for adding bootstrap keys to policy.
+- New binary name: 'zplc'.
+
+
 ## [0.1.0] - 2025-03-27
 
 _Initial Release._  In which the compiler source code was ported over
@@ -8,5 +14,6 @@ repository.
 
 
 
+[0.2.0]: https://github.com/org-zpr/zpr-compiler/releases/tag/v0.2.0
 [0.1.0]: https://github.com/org-zpr/zpr-compiler/releases/tag/v0.1.0
 


### PR DESCRIPTION
Never did update CHANGELOG or make a tag when we went to 0.2.0.  This does that.  Well, I'll add the tag on main once we commit.