### PR TITLE
new comment syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## In Progress
 
-(n/a)
-
+- New comment syntax: '#' or '//' which consumes to EOL. The old 'note:'
+  and 'comment:' syntax is removed.
 
 ## [0.4.0] - 2025-06-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "zplc"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zplc"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [dependencies]

--- a/src/zplstr.rs
+++ b/src/zplstr.rs
@@ -159,14 +159,6 @@ impl ZPLStrBuilder {
         matches!(self.name.to_lowercase().as_str(), "a" | "an")
     }
 
-    /// True if the atom collected so far is "note" or "comment".
-    pub fn is_comment_start(&self) -> bool {
-        if self.tuple {
-            return false;
-        }
-        matches!(self.name.to_lowercase().as_str(), "note" | "comment")
-    }
-
     pub fn build(&self) -> ZPLStr {
         if self.tuple {
             return ZPLStr::new_tuple(&self.name, &self.value);

--- a/test-data/bas-01.zpl
+++ b/test-data/bas-01.zpl
@@ -2,27 +2,25 @@ allow clearance:classified government users to access classified
 services.
 
 
-note: ZPL author must define any auth services and ensure that
-note: the service name is present in the configuration.
+# ZPL author must define any auth services and ensure that
+# the service name is present in the configuration.
 
 define AuthService as a service
 
-note: define AuthService as a service with device.zpr.adapter.cn:'bas.zpr.org'
-note: consider "define AuthService as a service on devices with cn:'bas.zpr.org'
+// define AuthService as a service with device.zpr.adapter.cn:'bas.zpr.org'
+// consider "define AuthService as a service on devices with cn:'bas.zpr.org'
 
-note: ZPL author must explicitly grant access to any authentication
-note: services for adapters.
-note: Access for the visa service is added by the compiler.
+// ZPL author must explicitly grant access to any authentication
+// services for adapters.
+// Access for the visa service is added by the compiler.
 
 
 allow zpr.adapter.cn: devices to access AuthService
 
-
-
-note: In policy you can define "administrators" in any way you want.
+# In policy you can define "administrators" in any way you want.
 define NetAdmins as users with device.zpr.adapter.cn:'admin.zpr.org'
 
-note: VisaService is a reserved name.
+# VisaService is a reserved name.
 allow NetAdmins to access VisaService
 
 

--- a/test-data/integ-conform-policy.zpl
+++ b/test-data/integ-conform-policy.zpl
@@ -1,21 +1,21 @@
 define adapter as a device with zpr.adapter.cn
 
-Note: Our node offers PING too
+# Our node offers PING too
 define PingableNode as a service with device.zpr.adapter.cn:'node.zpr.org'
 
-Note: Three services, all offered by same adapter
+# Three services, all offered by same adapter
 define WebService as a service with device.zpr.adapter.cn:'service.zpr.org'
 define IPerfService as a service with device.zpr.adapter.cn:'service.zpr.org'
 define PingableService as a service with device.zpr.adapter.cn:'service.zpr.org'
 
 define SpecialClient as an adapter with device.zpr.adapter.cn:'client.zpr.org'
 
-Note: the SpecialClient can access three services
+# the SpecialClient can access three services
 allow SpecialClient to access WebService
 allow SpecialClient to access IPerfService
 allow SpecialClient to access PingableService
 
-Note: any connected adapter can ping the node
+# any connected adapter can ping the node
 allow adapter to access PingableNode
 
 allow zpr.adapter.cn:'client.zpr.org' devices to access VisaService

--- a/test-data/integ-v4-1node-2agent-ping.zpl
+++ b/test-data/integ-v4-1node-2agent-ping.zpl
@@ -1,5 +1,5 @@
-Note: two adapters: they can ping each other
-Note: One node, one visa service: they can ping each other
+# two adapters: they can ping each other
+# One node, one visa service: they can ping each other
 
 define adapter as a device with zpr.adapter.cn
 

--- a/test-data/integ-v4-1node-3agent-ping.zpl
+++ b/test-data/integ-v4-1node-3agent-ping.zpl
@@ -1,5 +1,5 @@
-Note: three adapters: they can ping each other
-Note: One node, one visa service: they can ping each other
+# three adapters: they can ping each other
+# One node, one visa service: they can ping each other
 
 define adapter as a device with zpr.adapter.cn
 

--- a/test-data/m3-ping-and-http.zpl
+++ b/test-data/m3-ping-and-http.zpl
@@ -1,6 +1,6 @@
-Note: Allow a specific adapter to host a service and allow
-Note: another adapter to access it.
-Note: Since we don't yet authenticate users, this policy is expressed using endpoints.
+# Allow a specific adapter to host a service and allow
+# another adapter to access it.
+# Since we don't yet authenticate users, this policy is expressed using endpoints.
 
 
 define adapter as a device with zpr.adapter.cn

--- a/test-data/m3-ping-only.zpl
+++ b/test-data/m3-ping-only.zpl
@@ -1,5 +1,5 @@
-Note: Allow a specific agent to ping another specific agent.
-Note: Since we don't yet authenticate users, this policy is expressed using endpoints.
+# Allow a specific agent to ping another specific agent.
+# Since we don't yet authenticate users, this policy is expressed using endpoints.
 
 
 define adapter as a device with zpr.adapter.cn

--- a/test-data/rfc15-006-todo.zpl
+++ b/test-data/rfc15-006-todo.zpl
@@ -1,4 +1,4 @@
-Note: Will not work until we support `without`.
+# Will not work until we support `without`.
 
-Note: allow users without role:intern to access internal services.
+// allow users without role:intern to access internal services.
 

--- a/test-data/rfc15-012-todo.zpl
+++ b/test-data/rfc15-012-todo.zpl
@@ -1,5 +1,5 @@
-Note: Will not work until we support "from" keyword.
+# Will not work until we support "from" keyword.
 
-Note: define employee as a user with an ID-number and multiple roles from
-Note:   ActiveDirectory and with optional tags full-time, part-time, and
-Note:   intern from Tag-Service.
+// define employee as a user with an ID-number and multiple roles from
+//   ActiveDirectory and with optional tags full-time, part-time, and
+//   intern from Tag-Service.

--- a/test-data/rfc15-014-todo.zpl
+++ b/test-data/rfc15-014-todo.zpl
@@ -1,4 +1,4 @@
-Note: Requires 'never' support
+# Requires 'never' support
 
-Note: never allow internet-gateways to access internal services.
+// never allow internet-gateways to access internal services.
 

--- a/test-data/vs-auth-test.zpl
+++ b/test-data/vs-auth-test.zpl
@@ -1,6 +1,6 @@
-Note: Allow a specific adapter to host a service and allow
-Note: another adapter to access it.
-Note: Since we don't yet authenticate users, this policy is expressed using endpoints.
+# Allow a specific adapter to host a service and allow
+# another adapter to access it.
+# Since we don't yet authenticate users, this policy is expressed using endpoints.
 
 
 define adapter as a device with cn


### PR DESCRIPTION
Comments now start with "#" or "//".

Only incremented patch version since this only changes how ZPL is read not how policy is generated.

Closes #26 