### PR TITLE
added signal to v2 binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,6 @@ dependencies = [
 [[package]]
 name = "zpr-policy"
 version = "0.11.0"
-source = "git+https://github.com/org-zpr/zpr-policy-rs.git?tag=v0.8.4#1cec2f7346a3787906a515dbd80cd6818ce259ec"
 dependencies = [
  "capnp",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ ring = "0.17.8"
 serde = { version = "1.0.217", features = ["derive"] }
 thiserror = "2.0.8"
 toml = "0.9.7"
-zpr-policy = { git = "https://github.com/org-zpr/zpr-policy-rs.git", tag = "v0.8.4", features = ["v1", "v2"]}
+zpr-policy = { git = "https://github.com/org-zpr/zpr-policy-rs.git", tag = "v0.8.5", features = ["v1", "v2"]}


### PR DESCRIPTION
NOTE this will not compile until
- the changes in https://github.com/org-zpr/zpr-policy/pull/21 are approved and merged
- a PR in zpr-policy-rs is generated and marged
- new release created in zpr-policy and new tag added to zpr-policy-rs (0.8.5) 

Does a new release need to be made in zpr-policy-go since the v2 bin is not used in the go VS?