### PR TITLE
update readme and changelog now ready as 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## pending
 
+- (empty)
+
+## [0.9.1] - 2025-10-14
+
 - Can now encode set value attribute properly.
 - Support for our full port-spec for the protocol and service port
   value.
@@ -102,6 +106,7 @@ repository.
 
 
 
+[0.9.1]: https://github.com/org-zpr/zpr-compiler/releases/tag/v0.9.1
 [0.8.1]: https://github.com/org-zpr/zpr-compiler/releases/tag/v0.8.1
 [0.8.0]: https://github.com/org-zpr/zpr-compiler/releases/tag/v0.8.0
 [0.7.0]: https://github.com/org-zpr/zpr-compiler/releases/tag/v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,8 @@ dependencies = [
 
 [[package]]
 name = "zpr-policy"
-version = "0.11.0"
+version = "0.12.0"
+source = "git+https://github.com/org-zpr/zpr-policy-rs.git?tag=v0.8.5#2e3b673b613bede3a78686318c3418a461ca9b88"
 dependencies = [
  "capnp",
  "prost",

--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ contents of a "compiled" binary policy, `zpdump`.
 - Help is available via `zplc -h`
 
 
+## How to build
+
+The compiler makes use of our binary policy encodings which are currently
+in a private repository. We have bundled the rust repo along with the
+current compiler [release](https://github.com/org-zpr/zpr-compiler/releases).
+
+First download and unpack `zpr-policy-rs.tar.gz`. Then point the
+zpr-compiler `Cargo.toml` at the path instead of the github repo. So change
+this:
+
+``` 
+zpr-policy = { git = "https://github.com/org-zpr/zpr-policy-rs.git", tag = "v0.8.5", features = ["v1", "v2"]}
+```
+
+to this:
+
+```
+zpr-policy = { path = "/path/to/zpr-policy-rs", tag = "v0.8.5", features = ["v1", "v2"]}
+```
+
+
 ## TODO
 
 Work is ongoing to accept the full ZPL syntax. Note that it is one


### PR DESCRIPTION
Once this is in I'll tag as 0.9.1 and make a release that includes the `zpr-policy-rs` sources.