### PR TITLE
ready for capn proto 0.23.0 and lib-policy-rs 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,7 @@ dependencies = [
 [[package]]
 name = "zpr-policy"
 version = "0.13.0"
+source = "git+https://github.com/org-zpr/zpr-policy-rs.git?tag=v0.9.0#3acf76e60c35bb17693b40568b56122e1a521b13"
 dependencies = [
  "capnp",
  "capnpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ ring = "0.17.8"
 serde = { version = "1.0.217", features = ["derive"] }
 thiserror = "2.0.8"
 toml = "0.9.7"
-zpr-policy = { git = "https://github.com/org-zpr/zpr-policy-rs.git", tag = "v0.8.6", features = ["v1", "v2"]}
+zpr-policy = { git = "https://github.com/org-zpr/zpr-policy-rs.git", tag = "v0.9.0", features = ["v1", "v2"]}


### PR DESCRIPTION
Once the zpr-policy and zpr-policy-rs PRs go through, and we have versioned up the zpr-policy-rs, this PR here should be applied to pick it up.

Related:
* https://github.com/org-zpr/zpr-policy/pull/23
* https://github.com/org-zpr/zpr-policy-rs/pull/25