### PR TITLE
write keys into policy (with policy 0.9.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,6 @@ dependencies = [
 [[package]]
 name = "zpr-policy"
 version = "0.13.0"
-source = "git+https://github.com/org-zpr/zpr-policy-rs.git?tag=v0.9.0#3acf76e60c35bb17693b40568b56122e1a521b13"
 dependencies = [
  "capnp",
  "capnpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zplc"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 
 [dependencies]
@@ -18,4 +18,4 @@ ring = "0.17.8"
 serde = { version = "1.0.217", features = ["derive"] }
 thiserror = "2.0.8"
 toml = "0.9.7"
-zpr-policy = { git = "https://github.com/org-zpr/zpr-policy-rs.git", tag = "v0.9.0", features = ["v1", "v2"]}
+zpr-policy = { git = "https://github.com/org-zpr/zpr-policy-rs.git", tag = "v0.9.1", features = ["v1", "v2"]}

--- a/src/bin/zpdump.rs
+++ b/src/bin/zpdump.rs
@@ -1,7 +1,8 @@
 use bytes::Bytes;
 use clap::Parser;
 use std::path::PathBuf;
-use zplc::dump;
+use zplc::dumpv1::dump_v1;
+use zplc::dumpv2::dump_v2;
 
 /// ZPL Policy Dumper
 ///
@@ -23,9 +24,9 @@ fn main() {
     let encoded = std::fs::read(cli.zpl).expect("failed to read binary policy file");
     let encoded_buf = Bytes::from(encoded);
     if fname.ends_with(".bin2") {
-        dump::dump_v2(&fname, encoded_buf);
+        dump_v2(&fname, encoded_buf);
     } else {
-        dump::dump_v1(&fname, encoded_buf);
+        dump_v1(&fname, encoded_buf);
     }
     std::process::exit(exit_code);
 }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,558 +1,12 @@
-use ::polio::policy_capnp;
 use colored::Colorize;
 use polio::polio;
 use std::convert::TryInto;
 use std::net::IpAddr;
 
-use base64::prelude::*;
-
-use bytes::Bytes;
-use openssl::rsa::Rsa;
-use openssl::x509::X509;
-use prost::Message;
-
-use crate::compiler::get_compiler_version;
-use crate::policybinaryv1::NO_PROC;
 use crate::protocols::IanaProtocol;
 use crate::zpl;
 
-pub fn dump_v1(fname: &str, encoded_buf: Bytes) {
-    let container: polio::PolicyContainer = polio::PolicyContainer::decode(encoded_buf)
-        .expect("failed to decode binary (v1) policy file");
-
-    let (current_version, version_mismatch) = {
-        let (major, minor, patch) = get_compiler_version();
-        (
-            format!("{}.{}.{}", major, minor, patch),
-            container.version_major != major
-                || container.version_minor != minor
-                || container.version_patch != patch,
-        )
-    };
-
-    println!("              file: {}", fname.yellow());
-    print!(
-        "  compiler_version: {}.{}.{}",
-        format!("{}", container.version_major).yellow(),
-        format!("{}", container.version_minor).yellow(),
-        format!("{}", container.version_patch).yellow()
-    );
-    if version_mismatch {
-        println!(" (current is {})", current_version.red());
-    } else {
-        println!();
-    }
-    println!("       policy_date: {}", container.policy_date.yellow());
-    println!(
-        "    policy_version: {}",
-        format!("{}", container.policy_version).yellow()
-    );
-    println!("   policy_revision: {}", container.policy_revision.yellow());
-    println!("   policy_metadata: {}", container.policy_metadata.yellow());
-    println!(
-        "         signature: {}",
-        if container.signature.is_empty() {
-            "none".red()
-        } else {
-            "yes (not checked)".yellow()
-        }
-    );
-    println!();
-
-    let encoded_buf = Bytes::from(container.policy);
-    let pol: polio::Policy = polio::Policy::decode(encoded_buf).expect("failed to decode policy");
-
-    print!(
-        "       connection rules: {:>3}",
-        format!("{}", pol.connects.len()).yellow()
-    );
-    println!(
-        "      communication policies: {:>3}",
-        format!("{}", pol.policies.len()).yellow()
-    );
-    print!(
-        "               services: {:>3}",
-        format!("{}", pol.services.len()).yellow()
-    );
-    println!(
-        "                  procedures: {:>3}",
-        format!("{}", pol.procs.len()).yellow()
-    );
-    print!(
-        "                  links: {:>3}",
-        format!("{}", pol.links.len()).yellow()
-    );
-    println!(
-        "                certificates: {:>3}",
-        format!("{}", pol.certificates.len()).yellow()
-    );
-    print!(
-        "         attribute keys: {:>3}",
-        format!("{}", pol.attr_key_index.len()).yellow()
-    );
-    println!(
-        "            attribute values: {:>3}",
-        format!("{}", pol.attr_val_index.len()).yellow()
-    );
-    print!(
-        " configuration settings: {:>3}",
-        format!("{}", pol.config.len()).yellow()
-    );
-    println!(
-        "                 public keys: {:>3}",
-        format!("{}", pol.pubkeys.len()).yellow()
-    );
-
-    if !pol.connects.is_empty() {
-        print_section_hdr("CONNECTS");
-        for (i, connect) in pol.connects.iter().enumerate() {
-            print!("connect {}", format!("{}", i + 1).yellow());
-            if connect.proc != NO_PROC {
-                println!("     proc {}", format!("{:03}", connect.proc).yellow());
-            } else {
-                println!();
-            }
-
-            for aexp in &connect.attr_exprs {
-                println!(
-                    "     {}",
-                    attr_exp_to_string(aexp, &pol.attr_key_index, &pol.attr_val_index).yellow()
-                );
-            }
-        }
-    }
-
-    if !pol.policies.is_empty() {
-        print_section_hdr("COMMUNICATION POLICIES");
-        for (i, cp) in pol.policies.iter().enumerate() {
-            print!("policy {}", format!("{}", i + 1).yellow());
-            if !cp.allow {
-                print!(" {}", "DENY".red().bold());
-            }
-            println!();
-            println!("     service_id: {}", cp.service_id.yellow());
-            println!("             id: {}", cp.id.yellow());
-            println!("          scope: {}", scopes_to_string(&cp.scope).yellow());
-            for cond in &cp.cli_conditions {
-                println!(
-                    "     cond {} {}:",
-                    "cli".bold().italic(),
-                    format!("{}", cond.id).yellow()
-                );
-                for aexp in &cond.attr_exprs {
-                    println!(
-                        "         {} {}",
-                        format!("{}", "󰞘").dimmed(),
-                        attr_exp_to_string(aexp, &pol.attr_key_index, &pol.attr_val_index).yellow()
-                    );
-                }
-            }
-            for cond in &cp.svc_conditions {
-                println!(
-                    "     cond {} {}:",
-                    "svc".bold().italic(),
-                    format!("{}", cond.id).yellow()
-                );
-                for aexp in &cond.attr_exprs {
-                    println!(
-                        "         {} {}",
-                        format!("{}", "󰞘").dimmed(),
-                        attr_exp_to_string(aexp, &pol.attr_key_index, &pol.attr_val_index).yellow()
-                    );
-                }
-            }
-        }
-    }
-
-    if !pol.services.is_empty() {
-        print_section_hdr("SERVICES");
-        for (i, service) in pol.services.iter().enumerate() {
-            println!("service {}", format!("{}", i + 1).yellow());
-            println!(
-                "          type: {}",
-                svct_to_string(service.r#type).yellow()
-            );
-            println!("          name: {}", service.name.yellow());
-            println!("        prefix: {}", service.prefix.yellow());
-            println!("        domain: {}", service.domain.yellow());
-            if service.query_uri.is_empty() {
-                println!("     query_uri: {}", "unsupported".red());
-            } else {
-                println!("     query_uri: {}", service.query_uri.yellow());
-            }
-            if service.validate_uri.is_empty() {
-                println!("  validate_uri: {}", "unsupported".red());
-            } else {
-                println!("  validate_uri: {}", service.validate_uri.yellow());
-            }
-            // auth type services have attributes.
-            if service.r#type == polio::SvcT::SvctAuth as i32 {
-                if service.attr_map.is_empty() {
-                    println!("         attrs: {}", "none".red());
-                } else {
-                    println!(
-                        "         attrs: {}",
-                        if service.attr_map.is_empty() {
-                            "[]".yellow()
-                        } else {
-                            "[".yellow()
-                        }
-                    );
-                    for (ts_attr, zattr) in &service.attr_map {
-                        println!(
-                            "                  {} -> {}",
-                            ts_attr.yellow(),
-                            zattr.white()
-                        );
-                    }
-                    if !service.attr_map.is_empty() {
-                        println!("                {}", "]".yellow());
-                    }
-                }
-                if service.id_attrs.is_empty() {
-                    println!("      id_attrs: {}", "none".red());
-                } else {
-                    println!(
-                        "      id_attrs: {}",
-                        array_to_string(&service.id_attrs).yellow()
-                    );
-                }
-            }
-        }
-    }
-
-    if !pol.procs.is_empty() {
-        print_section_hdr("PROCEDURES");
-        for (i, proc) in pol.procs.iter().enumerate() {
-            println!("proc {}", format!("{:03}", i).yellow());
-            for (j, instr) in instrs_to_strings(&proc.proc).iter().enumerate() {
-                println!(
-                    "     {:03}: {}",
-                    format!("{:03}", j).dimmed(),
-                    instr.yellow()
-                );
-            }
-        }
-    }
-
-    if !pol.links.is_empty() {
-        print_section_hdr("LINKS");
-        for (i, link) in pol.links.iter().enumerate() {
-            println!("link {}", format!("{}", i + 1).yellow());
-            for term in &link.terms {
-                println!(
-                    "     source: {}  ->  dest: {}",
-                    parse_addr_to_string(&link.source_id).yellow(),
-                    parse_addr_to_string(&term.zpr_id).yellow()
-                );
-                println!(
-                    "     @ {}:{}",
-                    term.host.yellow(),
-                    format!("{}", term.port).yellow()
-                );
-                println!(
-                    "     key: {}",
-                    BASE64_STANDARD.encode(term.key.as_slice()).yellow()
-                );
-                println!(
-                    "     cost: {}    ext_auth: {}",
-                    format!("{}", term.cost).yellow(),
-                    format!("{}", term.ext_auth).yellow()
-                );
-            }
-        }
-    }
-
-    if !pol.certificates.is_empty() {
-        print_section_hdr("CERTIFICATES");
-        for (i, cert) in pol.certificates.iter().enumerate() {
-            println!("cert {}", format!("{}", i + 1).yellow());
-            println!(
-                "     name: {}    ( ID = {} )",
-                cert.name.yellow(),
-                format!("{}", cert.id).yellow()
-            );
-            println!("     data:");
-            match X509::from_der(&cert.asn1data) {
-                Ok(x509cert) => match x509cert.to_text() {
-                    Ok(text) => {
-                        let text = String::from_utf8_lossy(&text);
-                        for line in text.split('\n') {
-                            println!("         {}", line.yellow());
-                        }
-                    }
-                    Err(e) => {
-                        println!("     !ERR! {}", e);
-                    }
-                },
-                Err(e) => {
-                    println!("     !ERR! {}", e);
-                }
-            }
-        }
-    }
-
-    if !(pol.attr_key_index.is_empty() && pol.attr_val_index.is_empty()) {
-        print_section_hdr("ATTRIBUTES");
-        let key_idx_len = pol.attr_key_index.len();
-        let val_idx_len = pol.attr_val_index.len();
-        println!("       {}{:>33}", "KEYS".bold(), "VALUES".bold());
-        for i in 0..key_idx_len.max(val_idx_len) {
-            if i < key_idx_len && i < val_idx_len {
-                print!(
-                    "     {:>3}: {:<24}",
-                    format!("{}", i).yellow(),
-                    pol.attr_key_index[i].yellow()
-                );
-                println!(
-                    "  {:>3}: {}",
-                    format!("{}", i).yellow(),
-                    pol.attr_val_index[i].yellow()
-                );
-            } else if i < key_idx_len {
-                println!(
-                    "     {:>3}: {:<24}",
-                    format!("{}", i).yellow(),
-                    pol.attr_key_index[i].yellow()
-                );
-            } else {
-                println!(
-                    "{:>36}{:>3}: {}",
-                    "",
-                    format!("{}", i).yellow(),
-                    pol.attr_val_index[i].yellow()
-                );
-            }
-        }
-    }
-
-    if !pol.config.is_empty() {
-        print_section_hdr("CONFIGURATION SETTINGS");
-        for setting in &pol.config {
-            println!(
-                "     {} = {}",
-                config_setting_key_to_string(setting.key).yellow(),
-                config_val_to_string(&setting.val).yellow()
-            );
-        }
-    }
-
-    if !pol.pubkeys.is_empty() {
-        print_section_hdr("PUBLIC KEYS");
-        for (i, pubkey) in pol.pubkeys.iter().enumerate() {
-            println!(
-                "pubkey {}    CN = {}",
-                format!("{}", i + 1).yellow(),
-                pubkey.cn.yellow()
-            );
-            match Rsa::public_key_from_der(&pubkey.keydata) {
-                Ok(rsa) => match rsa.public_key_to_pem() {
-                    Ok(pem) => {
-                        let pem = String::from_utf8_lossy(&pem);
-                        for line in pem.split('\n') {
-                            println!("     {}", line.yellow());
-                        }
-                    }
-                    Err(e) => {
-                        println!("     !ERR! {}", e);
-                    }
-                },
-                Err(e) => {
-                    println!("     !ERR! {}", e);
-                }
-            }
-        }
-    }
-}
-
-pub fn dump_v2(fname: &str, encoded_buf: Bytes) {
-    let container_rdr = capnp::serialize::read_message(
-        &mut std::io::Cursor::new(encoded_buf),
-        capnp::message::ReaderOptions::new(),
-    )
-    .expect("failed to decode binary (v2) policy file");
-
-    let container = container_rdr
-        .get_root::<policy_capnp::policy_container::Reader>()
-        .expect("failed to get capn proto root of policy container");
-
-    let (current_version, version_mismatch) = {
-        let (major, minor, patch) = get_compiler_version();
-        (
-            format!("{}.{}.{}", major, minor, patch),
-            container.get_zplc_ver_major() != major
-                || container.get_zplc_ver_minor() != minor
-                || container.get_zplc_ver_patch() != patch,
-        )
-    };
-
-    println!("              file: {}", fname.yellow());
-    print!(
-        "  compiler_version: {}.{}.{}",
-        format!("{}", container.get_zplc_ver_major()).yellow(),
-        format!("{}", container.get_zplc_ver_minor()).yellow(),
-        format!("{}", container.get_zplc_ver_patch()).yellow()
-    );
-    if version_mismatch {
-        println!(" (current is {})", current_version.red());
-    } else {
-        println!();
-    }
-    println!(
-        "         signature: {}",
-        if !container.has_signature() {
-            "none".red()
-        } else {
-            "yes (not checked)".yellow()
-        }
-    );
-    println!();
-
-    if !container.has_policy() {
-        println!("error: {}", "No policy".red().bold());
-        return;
-    }
-
-    let policy_bytes = container.get_policy().unwrap();
-
-    let policy_rdr = capnp::serialize::read_message(
-        &mut std::io::Cursor::new(policy_bytes),
-        capnp::message::ReaderOptions::new(),
-    )
-    .expect("failed to decode binary (v2) policy component");
-
-    let policy = policy_rdr
-        .get_root::<policy_capnp::policy::Reader>()
-        .expect("failed to get capn proto root of policy");
-
-    println!(
-        "       policy_date: {}",
-        policy.get_created().unwrap().to_str().unwrap().yellow()
-    );
-    println!(
-        "    policy_version: {}",
-        format!("{}", policy.get_version()).yellow()
-    );
-    println!(
-        "   policy_metadata: {}",
-        policy.get_metadata().unwrap().to_str().unwrap().yellow()
-    );
-    if policy.has_com_policies() {
-        print_section_hdr("COMMUNICATION POLICIES");
-        for (i, cp) in policy.get_com_policies().unwrap().iter().enumerate() {
-            print!("policy {}", format!("{}", i + 1).yellow());
-            if cp.has_zpl() {
-                print!("  {}", cp.get_zpl().unwrap().to_str().unwrap().green());
-            } else {
-                print!("  {}", "(zpl missing)".red());
-            }
-            if !cp.get_allow() {
-                print!(" {}", "DENY".red().bold());
-            }
-            println!();
-            println!(
-                "     service_id: {}",
-                cp.get_service_id().unwrap().to_str().unwrap().yellow()
-            );
-            println!(
-                "             id: {}",
-                cp.get_id().unwrap().to_str().unwrap().yellow()
-            );
-            println!(
-                "          scope: {}",
-                scopes_v2_to_string(&cp.get_scope().unwrap()).yellow()
-            );
-            if cp.has_client_conds() {
-                for cond in cp.get_client_conds().unwrap() {
-                    println!("     cond {} :", "cli".bold().italic());
-                    println!(
-                        "         {} {}",
-                        format!("{}", "󰞘").dimmed(),
-                        attr_exp_v2_to_string(&cond).yellow()
-                    );
-                }
-            }
-            if cp.has_service_conds() {
-                for cond in cp.get_service_conds().unwrap() {
-                    println!("     cond {} :", "svc".bold().italic());
-                    println!(
-                        "         {} {}",
-                        format!("{}", "󰞘").dimmed(),
-                        attr_exp_v2_to_string(&cond).yellow()
-                    );
-                }
-            }
-        }
-    }
-}
-
-fn scopes_v2_to_string<'a>(
-    scopes: &::capnp::struct_list::Reader<'a, policy_capnp::scope::Owned>,
-) -> String {
-    let mut scope_strings = Vec::new();
-
-    for scope in scopes.iter() {
-        let mut scope_string = String::new();
-        let prot_num = scope.get_protocol();
-        match TryInto::<IanaProtocol>::try_into(prot_num as u32) {
-            Ok(proto) => scope_string.push_str(&proto.to_string()),
-            Err(_) => {
-                scope_string.push_str(&format!("!INVALID_PROTOCOL<{}>!", scope.get_protocol()));
-            }
-        };
-
-        match scope.which() {
-            Ok(policy_capnp::scope::Port(pnum)) => {
-                scope_string.push_str(&format!(" port {}", pnum.get_port_num()));
-            }
-            Ok(policy_capnp::scope::PortRange(pr)) => {
-                scope_string.push_str(&format!(" ports {}-{}", pr.get_low(), pr.get_high()));
-            }
-            Err(::capnp::NotInSchema(_)) => {
-                scope_string.push_str(" (no ports)");
-            }
-        }
-
-        scope_strings.push(scope_string);
-    }
-
-    scope_strings.join(", ")
-}
-
-fn attr_exp_v2_to_string(exp: &policy_capnp::attr_expr::Reader) -> String {
-    let mut s = String::new();
-    s.push_str(&exp.get_key().unwrap().to_str().unwrap());
-    let opstr = match exp.get_op().unwrap() {
-        policy_capnp::AttrOp::Eq => "EQ",
-        policy_capnp::AttrOp::Ne => "NE",
-        policy_capnp::AttrOp::Has => "HAS",
-        policy_capnp::AttrOp::Excludes => "EXCLUDES",
-    };
-    s.push_str(&format!(" {} ", opstr));
-    if exp.has_value() {
-        let vals = exp.get_value().unwrap();
-        if vals.len() > 1 {
-            s.push_str("[");
-            s.push_str(
-                &vals
-                    .iter()
-                    .map(|v| v.unwrap().to_str().unwrap())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            );
-            s.push_str("]");
-        } else if vals.len() == 1 {
-            s.push_str(&vals.get(0).unwrap().to_str().unwrap());
-        } else {
-            s.push_str("\"\"");
-        }
-    } else {
-        s.push_str("(no value)")
-    }
-    s
-}
-
-fn print_section_hdr(title: &str) {
+pub fn print_section_hdr(title: &str) {
     println!();
     println!(
         "{}{}{} {}",
@@ -563,14 +17,14 @@ fn print_section_hdr(title: &str) {
     );
 }
 
-fn config_setting_key_to_string(key: u32) -> String {
+pub fn config_setting_key_to_string(key: u32) -> String {
     match key {
         zpl::CONFIG_KEY_MAX_VISA_LIFETIME => String::from("max_visa_lifetime"),
         _ => format!("key #{}", key),
     }
 }
 
-fn config_val_to_string(optval: &Option<polio::config_setting::Val>) -> String {
+pub fn config_val_to_string(optval: &Option<polio::config_setting::Val>) -> String {
     match optval {
         Some(polio::config_setting::Val::Sv(s)) => s.clone(),
         Some(polio::config_setting::Val::U32v(n)) => format!("{}", n),
@@ -580,7 +34,7 @@ fn config_val_to_string(optval: &Option<polio::config_setting::Val>) -> String {
     }
 }
 
-fn parse_addr_to_string(addr_bytes: &[u8]) -> String {
+pub fn parse_addr_to_string(addr_bytes: &[u8]) -> String {
     match parse_addr(addr_bytes) {
         Ok(addr) => addr.to_string(),
         Err(_) => String::from("!INVALID_ADDR!"),
@@ -602,7 +56,7 @@ fn parse_addr(addr_bytes: &[u8]) -> Result<IpAddr, String> {
     }
 }
 
-fn instrs_to_strings(instrs: &[polio::Instruction]) -> Vec<String> {
+pub fn instrs_to_strings(instrs: &[polio::Instruction]) -> Vec<String> {
     instrs.iter().map(instr_to_string).collect::<Vec<String>>()
 }
 
@@ -643,14 +97,14 @@ fn flagt_to_string(flag: i32) -> String {
     })
 }
 
-fn svct_to_string(svct: i32) -> String {
+pub fn svct_to_string(svct: i32) -> String {
     String::from(match polio::SvcT::try_from(svct) {
         Ok(st) => st.as_str_name(),
         Err(_) => "!ERR!",
     })
 }
 
-fn scopes_to_string(scopes: &[polio::Scope]) -> String {
+pub fn scopes_to_string(scopes: &[polio::Scope]) -> String {
     scopes
         .iter()
         .map(scope_to_string)
@@ -695,7 +149,7 @@ fn scope_to_string(scope: &polio::Scope) -> String {
     s
 }
 
-fn attr_exp_to_string(exp: &polio::AttrExpr, keys: &[String], values: &[String]) -> String {
+pub fn attr_exp_to_string(exp: &polio::AttrExpr, keys: &[String], values: &[String]) -> String {
     let mut s = String::new();
     s.push_str(&keys[exp.key as usize]);
     s.push_str(&format!(" {} ", attr_opt_t_to_string(exp.op)));
@@ -710,7 +164,7 @@ fn attr_opt_t_to_string(opval: i32) -> String {
     })
 }
 
-fn array_to_string(arr: &[String]) -> String {
+pub fn array_to_string(arr: &[String]) -> String {
     if arr.is_empty() {
         return String::from("[]");
     }

--- a/src/dumpv1.rs
+++ b/src/dumpv1.rs
@@ -1,0 +1,368 @@
+use colored::Colorize;
+use polio::polio;
+
+use base64::prelude::*;
+
+use bytes::Bytes;
+use openssl::rsa::Rsa;
+use openssl::x509::X509;
+use prost::Message;
+
+use crate::compiler::get_compiler_version;
+use crate::dump;
+use crate::policybinaryv1::NO_PROC;
+
+pub fn dump_v1(fname: &str, encoded_buf: Bytes) {
+    let container: polio::PolicyContainer = polio::PolicyContainer::decode(encoded_buf)
+        .expect("failed to decode binary (v1) policy file");
+
+    let (current_version, version_mismatch) = {
+        let (major, minor, patch) = get_compiler_version();
+        (
+            format!("{}.{}.{}", major, minor, patch),
+            container.version_major != major
+                || container.version_minor != minor
+                || container.version_patch != patch,
+        )
+    };
+
+    println!("              file: {}", fname.yellow());
+    print!(
+        "  compiler_version: {}.{}.{}",
+        format!("{}", container.version_major).yellow(),
+        format!("{}", container.version_minor).yellow(),
+        format!("{}", container.version_patch).yellow()
+    );
+    if version_mismatch {
+        println!(" (current is {})", current_version.red());
+    } else {
+        println!();
+    }
+    println!("       policy_date: {}", container.policy_date.yellow());
+    println!(
+        "    policy_version: {}",
+        format!("{}", container.policy_version).yellow()
+    );
+    println!("   policy_revision: {}", container.policy_revision.yellow());
+    println!("   policy_metadata: {}", container.policy_metadata.yellow());
+    println!(
+        "         signature: {}",
+        if container.signature.is_empty() {
+            "none".red()
+        } else {
+            "yes (not checked)".yellow()
+        }
+    );
+    println!();
+
+    let encoded_buf = Bytes::from(container.policy);
+    let pol: polio::Policy = polio::Policy::decode(encoded_buf).expect("failed to decode policy");
+
+    print!(
+        "       connection rules: {:>3}",
+        format!("{}", pol.connects.len()).yellow()
+    );
+    println!(
+        "      communication policies: {:>3}",
+        format!("{}", pol.policies.len()).yellow()
+    );
+    print!(
+        "               services: {:>3}",
+        format!("{}", pol.services.len()).yellow()
+    );
+    println!(
+        "                  procedures: {:>3}",
+        format!("{}", pol.procs.len()).yellow()
+    );
+    print!(
+        "                  links: {:>3}",
+        format!("{}", pol.links.len()).yellow()
+    );
+    println!(
+        "                certificates: {:>3}",
+        format!("{}", pol.certificates.len()).yellow()
+    );
+    print!(
+        "         attribute keys: {:>3}",
+        format!("{}", pol.attr_key_index.len()).yellow()
+    );
+    println!(
+        "            attribute values: {:>3}",
+        format!("{}", pol.attr_val_index.len()).yellow()
+    );
+    print!(
+        " configuration settings: {:>3}",
+        format!("{}", pol.config.len()).yellow()
+    );
+    println!(
+        "                 public keys: {:>3}",
+        format!("{}", pol.pubkeys.len()).yellow()
+    );
+
+    if !pol.connects.is_empty() {
+        dump::print_section_hdr("CONNECTS");
+        for (i, connect) in pol.connects.iter().enumerate() {
+            print!("connect {}", format!("{}", i + 1).yellow());
+            if connect.proc != NO_PROC {
+                println!("     proc {}", format!("{:03}", connect.proc).yellow());
+            } else {
+                println!();
+            }
+
+            for aexp in &connect.attr_exprs {
+                println!(
+                    "     {}",
+                    dump::attr_exp_to_string(aexp, &pol.attr_key_index, &pol.attr_val_index)
+                        .yellow()
+                );
+            }
+        }
+    }
+
+    if !pol.policies.is_empty() {
+        dump::print_section_hdr("COMMUNICATION POLICIES");
+        for (i, cp) in pol.policies.iter().enumerate() {
+            print!("policy {}", format!("{}", i + 1).yellow());
+            if !cp.allow {
+                print!(" {}", "DENY".red().bold());
+            }
+            println!();
+            println!("     service_id: {}", cp.service_id.yellow());
+            println!("             id: {}", cp.id.yellow());
+            println!(
+                "          scope: {}",
+                dump::scopes_to_string(&cp.scope).yellow()
+            );
+            for cond in &cp.cli_conditions {
+                println!(
+                    "     cond {} {}:",
+                    "cli".bold().italic(),
+                    format!("{}", cond.id).yellow()
+                );
+                for aexp in &cond.attr_exprs {
+                    println!(
+                        "         {} {}",
+                        format!("{}", "󰞘").dimmed(),
+                        dump::attr_exp_to_string(aexp, &pol.attr_key_index, &pol.attr_val_index)
+                            .yellow()
+                    );
+                }
+            }
+            for cond in &cp.svc_conditions {
+                println!(
+                    "     cond {} {}:",
+                    "svc".bold().italic(),
+                    format!("{}", cond.id).yellow()
+                );
+                for aexp in &cond.attr_exprs {
+                    println!(
+                        "         {} {}",
+                        format!("{}", "󰞘").dimmed(),
+                        dump::attr_exp_to_string(aexp, &pol.attr_key_index, &pol.attr_val_index)
+                            .yellow()
+                    );
+                }
+            }
+        }
+    }
+
+    if !pol.services.is_empty() {
+        dump::print_section_hdr("SERVICES");
+        for (i, service) in pol.services.iter().enumerate() {
+            println!("service {}", format!("{}", i + 1).yellow());
+            println!(
+                "          type: {}",
+                dump::svct_to_string(service.r#type).yellow()
+            );
+            println!("          name: {}", service.name.yellow());
+            println!("        prefix: {}", service.prefix.yellow());
+            println!("        domain: {}", service.domain.yellow());
+            if service.query_uri.is_empty() {
+                println!("     query_uri: {}", "unsupported".red());
+            } else {
+                println!("     query_uri: {}", service.query_uri.yellow());
+            }
+            if service.validate_uri.is_empty() {
+                println!("  validate_uri: {}", "unsupported".red());
+            } else {
+                println!("  validate_uri: {}", service.validate_uri.yellow());
+            }
+            // auth type services have attributes.
+            if service.r#type == polio::SvcT::SvctAuth as i32 {
+                if service.attr_map.is_empty() {
+                    println!("         attrs: {}", "none".red());
+                } else {
+                    println!(
+                        "         attrs: {}",
+                        if service.attr_map.is_empty() {
+                            "[]".yellow()
+                        } else {
+                            "[".yellow()
+                        }
+                    );
+                    for (ts_attr, zattr) in &service.attr_map {
+                        println!(
+                            "                  {} -> {}",
+                            ts_attr.yellow(),
+                            zattr.white()
+                        );
+                    }
+                    if !service.attr_map.is_empty() {
+                        println!("                {}", "]".yellow());
+                    }
+                }
+                if service.id_attrs.is_empty() {
+                    println!("      id_attrs: {}", "none".red());
+                } else {
+                    println!(
+                        "      id_attrs: {}",
+                        dump::array_to_string(&service.id_attrs).yellow()
+                    );
+                }
+            }
+        }
+    }
+
+    if !pol.procs.is_empty() {
+        dump::print_section_hdr("PROCEDURES");
+        for (i, proc) in pol.procs.iter().enumerate() {
+            println!("proc {}", format!("{:03}", i).yellow());
+            for (j, instr) in dump::instrs_to_strings(&proc.proc).iter().enumerate() {
+                println!(
+                    "     {:03}: {}",
+                    format!("{:03}", j).dimmed(),
+                    instr.yellow()
+                );
+            }
+        }
+    }
+
+    if !pol.links.is_empty() {
+        dump::print_section_hdr("LINKS");
+        for (i, link) in pol.links.iter().enumerate() {
+            println!("link {}", format!("{}", i + 1).yellow());
+            for term in &link.terms {
+                println!(
+                    "     source: {}  ->  dest: {}",
+                    dump::parse_addr_to_string(&link.source_id).yellow(),
+                    dump::parse_addr_to_string(&term.zpr_id).yellow()
+                );
+                println!(
+                    "     @ {}:{}",
+                    term.host.yellow(),
+                    format!("{}", term.port).yellow()
+                );
+                println!(
+                    "     key: {}",
+                    BASE64_STANDARD.encode(term.key.as_slice()).yellow()
+                );
+                println!(
+                    "     cost: {}    ext_auth: {}",
+                    format!("{}", term.cost).yellow(),
+                    format!("{}", term.ext_auth).yellow()
+                );
+            }
+        }
+    }
+
+    if !pol.certificates.is_empty() {
+        dump::print_section_hdr("CERTIFICATES");
+        for (i, cert) in pol.certificates.iter().enumerate() {
+            println!("cert {}", format!("{}", i + 1).yellow());
+            println!(
+                "     name: {}    ( ID = {} )",
+                cert.name.yellow(),
+                format!("{}", cert.id).yellow()
+            );
+            println!("     data:");
+            match X509::from_der(&cert.asn1data) {
+                Ok(x509cert) => match x509cert.to_text() {
+                    Ok(text) => {
+                        let text = String::from_utf8_lossy(&text);
+                        for line in text.split('\n') {
+                            println!("         {}", line.yellow());
+                        }
+                    }
+                    Err(e) => {
+                        println!("     !ERR! {}", e);
+                    }
+                },
+                Err(e) => {
+                    println!("     !ERR! {}", e);
+                }
+            }
+        }
+    }
+
+    if !(pol.attr_key_index.is_empty() && pol.attr_val_index.is_empty()) {
+        dump::print_section_hdr("ATTRIBUTES");
+        let key_idx_len = pol.attr_key_index.len();
+        let val_idx_len = pol.attr_val_index.len();
+        println!("       {}{:>33}", "KEYS".bold(), "VALUES".bold());
+        for i in 0..key_idx_len.max(val_idx_len) {
+            if i < key_idx_len && i < val_idx_len {
+                print!(
+                    "     {:>3}: {:<24}",
+                    format!("{}", i).yellow(),
+                    pol.attr_key_index[i].yellow()
+                );
+                println!(
+                    "  {:>3}: {}",
+                    format!("{}", i).yellow(),
+                    pol.attr_val_index[i].yellow()
+                );
+            } else if i < key_idx_len {
+                println!(
+                    "     {:>3}: {:<24}",
+                    format!("{}", i).yellow(),
+                    pol.attr_key_index[i].yellow()
+                );
+            } else {
+                println!(
+                    "{:>36}{:>3}: {}",
+                    "",
+                    format!("{}", i).yellow(),
+                    pol.attr_val_index[i].yellow()
+                );
+            }
+        }
+    }
+
+    if !pol.config.is_empty() {
+        dump::print_section_hdr("CONFIGURATION SETTINGS");
+        for setting in &pol.config {
+            println!(
+                "     {} = {}",
+                dump::config_setting_key_to_string(setting.key).yellow(),
+                dump::config_val_to_string(&setting.val).yellow()
+            );
+        }
+    }
+
+    if !pol.pubkeys.is_empty() {
+        dump::print_section_hdr("PUBLIC KEYS");
+        for (i, pubkey) in pol.pubkeys.iter().enumerate() {
+            println!(
+                "pubkey {}    CN = {}",
+                format!("{}", i + 1).yellow(),
+                pubkey.cn.yellow()
+            );
+            match Rsa::public_key_from_der(&pubkey.keydata) {
+                Ok(rsa) => match rsa.public_key_to_pem() {
+                    Ok(pem) => {
+                        let pem = String::from_utf8_lossy(&pem);
+                        for line in pem.split('\n') {
+                            println!("     {}", line.yellow());
+                        }
+                    }
+                    Err(e) => {
+                        println!("     !ERR! {}", e);
+                    }
+                },
+                Err(e) => {
+                    println!("     !ERR! {}", e);
+                }
+            }
+        }
+    }
+}

--- a/src/dumpv2.rs
+++ b/src/dumpv2.rs
@@ -1,0 +1,245 @@
+use ::polio::policy_capnp;
+use bytes::Bytes;
+use colored::Colorize;
+use openssl::rsa::Rsa;
+use std::convert::TryInto;
+
+use crate::compiler::get_compiler_version;
+use crate::dump;
+use crate::protocols::IanaProtocol;
+
+pub fn dump_v2(fname: &str, encoded_buf: Bytes) {
+    let container_rdr = capnp::serialize::read_message(
+        &mut std::io::Cursor::new(encoded_buf),
+        capnp::message::ReaderOptions::new(),
+    )
+    .expect("failed to decode binary (v2) policy file");
+
+    let container = container_rdr
+        .get_root::<policy_capnp::policy_container::Reader>()
+        .expect("failed to get capn proto root of policy container");
+
+    let (current_version, version_mismatch) = {
+        let (major, minor, patch) = get_compiler_version();
+        (
+            format!("{}.{}.{}", major, minor, patch),
+            container.get_zplc_ver_major() != major
+                || container.get_zplc_ver_minor() != minor
+                || container.get_zplc_ver_patch() != patch,
+        )
+    };
+
+    println!("              file: {}", fname.yellow());
+    print!(
+        "  compiler_version: {}.{}.{}",
+        format!("{}", container.get_zplc_ver_major()).yellow(),
+        format!("{}", container.get_zplc_ver_minor()).yellow(),
+        format!("{}", container.get_zplc_ver_patch()).yellow()
+    );
+    if version_mismatch {
+        println!(" (current is {})", current_version.red());
+    } else {
+        println!();
+    }
+    println!(
+        "         signature: {}",
+        if !container.has_signature() {
+            "none".red()
+        } else {
+            "yes (not checked)".yellow()
+        }
+    );
+    println!();
+
+    if !container.has_policy() {
+        println!("error: {}", "No policy".red().bold());
+        return;
+    }
+
+    let policy_bytes = container.get_policy().unwrap();
+
+    let policy_rdr = capnp::serialize::read_message(
+        &mut std::io::Cursor::new(policy_bytes),
+        capnp::message::ReaderOptions::new(),
+    )
+    .expect("failed to decode binary (v2) policy component");
+
+    let policy = policy_rdr
+        .get_root::<policy_capnp::policy::Reader>()
+        .expect("failed to get capn proto root of policy");
+
+    println!(
+        "       policy_date: {}",
+        policy.get_created().unwrap().to_str().unwrap().yellow()
+    );
+    println!(
+        "    policy_version: {}",
+        format!("{}", policy.get_version()).yellow()
+    );
+    println!(
+        "   policy_metadata: {}",
+        policy.get_metadata().unwrap().to_str().unwrap().yellow()
+    );
+    if policy.has_com_policies() {
+        dump::print_section_hdr("COMMUNICATION POLICIES");
+        for (i, cp) in policy.get_com_policies().unwrap().iter().enumerate() {
+            print!("policy {}", format!("{}", i + 1).yellow());
+            if cp.has_zpl() {
+                print!("  {}", cp.get_zpl().unwrap().to_str().unwrap().green());
+            } else {
+                print!("  {}", "(zpl missing)".red());
+            }
+            if !cp.get_allow() {
+                print!(" {}", "DENY".red().bold());
+            }
+            println!();
+            println!(
+                "     service_id: {}",
+                cp.get_service_id().unwrap().to_str().unwrap().yellow()
+            );
+            println!(
+                "             id: {}",
+                cp.get_id().unwrap().to_str().unwrap().yellow()
+            );
+            println!(
+                "          scope: {}",
+                scopes_v2_to_string(&cp.get_scope().unwrap()).yellow()
+            );
+            if cp.has_client_conds() {
+                for cond in cp.get_client_conds().unwrap() {
+                    println!("      cond {} :", "cli".bold().italic());
+                    println!(
+                        "         {} {}",
+                        format!("{}", "󰞘").dimmed(),
+                        attr_exp_v2_to_string(&cond).yellow()
+                    );
+                }
+            }
+            if cp.has_service_conds() {
+                for cond in cp.get_service_conds().unwrap() {
+                    println!("      cond {} :", "svc".bold().italic());
+                    println!(
+                        "         {} {}",
+                        format!("{}", "󰞘").dimmed(),
+                        attr_exp_v2_to_string(&cond).yellow()
+                    );
+                }
+            }
+        }
+    }
+    if policy.has_keys() {
+        dump::print_section_hdr("KEYS");
+        for (i, key) in policy.get_keys().unwrap().iter().enumerate() {
+            print!(
+                "{} id: {}",
+                format!("{:02}", i + 1).dimmed(),
+                key.get_id().unwrap().to_str().unwrap().yellow()
+            );
+            println!(
+                "  type: {}",
+                match key.get_key_type().unwrap() {
+                    policy_capnp::KeyMaterialT::RsaPub => "RSA_PUBLIC".green(),
+                }
+            );
+            let mut allowances = Vec::new();
+            let allows = key.get_key_allows().unwrap();
+            for allow in allows.iter() {
+                allowances.push(format!("+{:?}  ", allow.unwrap()));
+            }
+            println!("   allows:   {}", allowances.join("\n").yellow());
+
+            print!(
+                "   material: {}",
+                format!("({} bytes", key.get_key_data().unwrap().len()).dimmed()
+            );
+
+            if key.get_key_type().unwrap() != policy_capnp::KeyMaterialT::RsaPub {
+                println!("{}", ", omitted)".dimmed());
+            } else {
+                println!("{}", ")".dimmed());
+                match Rsa::public_key_from_der(&key.get_key_data().unwrap()) {
+                    Ok(rsa) => match rsa.public_key_to_pem() {
+                        Ok(pem) => {
+                            let pem = String::from_utf8_lossy(&pem);
+                            for line in pem.split('\n') {
+                                println!("     {}", line.yellow());
+                            }
+                        }
+                        Err(e) => {
+                            println!("     !ERR! {}", e);
+                        }
+                    },
+                    Err(e) => {
+                        println!("     !ERR! {}", e);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn scopes_v2_to_string<'a>(
+    scopes: &::capnp::struct_list::Reader<'a, policy_capnp::scope::Owned>,
+) -> String {
+    let mut scope_strings = Vec::new();
+
+    for scope in scopes.iter() {
+        let mut scope_string = String::new();
+        let prot_num = scope.get_protocol();
+        match TryInto::<IanaProtocol>::try_into(prot_num as u32) {
+            Ok(proto) => scope_string.push_str(&proto.to_string()),
+            Err(_) => {
+                scope_string.push_str(&format!("!INVALID_PROTOCOL<{}>!", scope.get_protocol()));
+            }
+        };
+
+        match scope.which() {
+            Ok(policy_capnp::scope::Port(pnum)) => {
+                scope_string.push_str(&format!(" port {}", pnum.get_port_num()));
+            }
+            Ok(policy_capnp::scope::PortRange(pr)) => {
+                scope_string.push_str(&format!(" ports {}-{}", pr.get_low(), pr.get_high()));
+            }
+            Err(::capnp::NotInSchema(_)) => {
+                scope_string.push_str(" (no ports)");
+            }
+        }
+
+        scope_strings.push(scope_string);
+    }
+
+    scope_strings.join(", ")
+}
+
+fn attr_exp_v2_to_string(exp: &policy_capnp::attr_expr::Reader) -> String {
+    let mut s = String::new();
+    s.push_str(&exp.get_key().unwrap().to_str().unwrap());
+    let opstr = match exp.get_op().unwrap() {
+        policy_capnp::AttrOp::Eq => "EQ",
+        policy_capnp::AttrOp::Ne => "NE",
+        policy_capnp::AttrOp::Has => "HAS",
+        policy_capnp::AttrOp::Excludes => "EXCLUDES",
+    };
+    s.push_str(&format!(" {} ", opstr));
+    if exp.has_value() {
+        let vals = exp.get_value().unwrap();
+        if vals.len() > 1 {
+            s.push_str("[");
+            s.push_str(
+                &vals
+                    .iter()
+                    .map(|v| v.unwrap().to_str().unwrap())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+            s.push_str("]");
+        } else if vals.len() == 1 {
+            s.push_str(&vals.get(0).unwrap().to_str().unwrap());
+        } else {
+            s.push_str("\"\"");
+        }
+    } else {
+        s.push_str("(no value)")
+    }
+    s
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ mod context;
 pub mod crypto;
 mod define;
 pub mod dump;
+pub mod dumpv1;
+pub mod dumpv2;
 pub mod errors;
 mod fabric;
 mod fabric_util;

--- a/tests/zpl-test.rs
+++ b/tests/zpl-test.rs
@@ -3,7 +3,8 @@ use std::env;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zplc::compilation::{CompilationBuilder, OutputFormat};
-use zplc::dump::{dump_v1, dump_v2};
+use zplc::dumpv1::dump_v1;
+use zplc::dumpv2::dump_v2;
 
 fn get_zpl_dir() -> PathBuf {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();


### PR DESCRIPTION
~~Waiting on updates to zpr-policy (https://github.com/org-zpr/zpr-policy/pull/25 )~~

This writes the bootstrap keys from the configuration into the v2 version of policy.

While I was in here I split the large dump.rs file into three: dump.rs has common functions, dumpv1 for v1 format and dumpv2 for v2 format.