### PR TITLE
openssl update to 0.10.78 to address various upstream security issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Addresses:
* https://github.com/org-zpr/zpr-compiler/security/dependabot/7
* https://github.com/org-zpr/zpr-compiler/security/dependabot/8
* https://github.com/org-zpr/zpr-compiler/security/dependabot/9
* https://github.com/org-zpr/zpr-compiler/security/dependabot/10
* https://github.com/org-zpr/zpr-compiler/security/dependabot/11