### PR TITLE
fixed values to accept unquoted floating points

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,6 +32,9 @@ pub enum CompilationError {
     #[error("illegal character for unquoted name literal at line {1}, column {2}: {0}")]
     IllegalNameLiteralChar(char, usize, usize),
 
+    #[error("invalid numeric value in unquoted string literal at line {1}, column {2}: {0}")]
+    IllegalNumericValue(String, usize, usize),
+
     #[error("illegal set start '{{' at line {0}, column {1}")]
     IllegalSetStart(usize, usize),
 

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -245,7 +245,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                 if !current_word.is_empty() && !reading_set {
                     if !current_word.is_sugar() {
                         tokens.push(Token::new_from_str(
-                            &current_word.build(),
+                            &current_word.build(line, col)?,
                             current_start.0,
                             current_start.1,
                         )?);
@@ -262,7 +262,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                     // Then treat as a delimiter
                     if !current_word.is_sugar() {
                         tokens.push(Token::new_from_str(
-                            &current_word.build(),
+                            &current_word.build(line, col)?,
                             current_start.0,
                             current_start.1,
                         )?);
@@ -280,7 +280,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                         if !reading_set {
                             if !current_word.is_sugar() {
                                 tokens.push(Token::new_from_str(
-                                    &current_word.build(),
+                                    &current_word.build(line, col)?,
                                     current_start.0,
                                     current_start.1,
                                 )?);
@@ -307,7 +307,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                         } else {
                             if !current_word.is_sugar() {
                                 tokens.push(Token::new_from_str(
-                                    &current_word.build(),
+                                    &current_word.build(line, col)?,
                                     current_start.0,
                                     current_start.1,
                                 )?);
@@ -338,7 +338,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                         }
                         if !current_word.is_sugar() {
                             tokens.push(Token::new_from_str(
-                                &current_word.build(),
+                                &current_word.build(line, col)?,
                                 current_start.0,
                                 current_start.1,
                             )?);
@@ -399,7 +399,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                         // We may have parsed a word prior to the comment.
                         if !current_word.is_empty() && !reading_set {
                             tokens.push(Token::new_from_str(
-                                &current_word.build(),
+                                &current_word.build(line, col)?,
                                 current_start.0,
                                 current_start.1,
                             )?);
@@ -449,7 +449,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                     reading_set = false;
                     // The current tuple we were reading is completed.
                     tokens.push(Token::new_from_str(
-                        &current_word.build(),
+                        &current_word.build(line, col)?,
                         current_start.0,
                         current_start.1,
                     )?);
@@ -505,7 +505,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                             if !reading_set {
                                 if !current_word.is_sugar() {
                                     tokens.push(Token::new_from_str(
-                                        &current_word.build(),
+                                        &current_word.build(line, col)?,
                                         current_start.0,
                                         current_start.1,
                                     )?);
@@ -562,7 +562,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
     }
     if !current_word.is_empty() && !current_word.is_sugar() {
         tokens.push(Token::new_from_str(
-            &current_word.build(),
+            &current_word.build(line, col)?,
             current_start.0,
             current_start.1,
         )?);
@@ -672,17 +672,37 @@ mod test {
         }
 
         {
-            // This will fail since a period is not allowed on an unquoted string
+            // This will fail since an unquoted value containing a period must
+            // be a decimal number ("green." is not).
             let zpl = "define alien as user with color:green.. allow aliens to access services";
             let res = super::tokenize_str(zpl, &CompilationCtx::default());
             assert!(res.is_err());
             let err = res.unwrap_err();
             match err {
-                super::CompilationError::IllegalStringLiteralChar(c, _line, _col) => {
-                    assert_eq!(c, '.');
+                super::CompilationError::IllegalNumericValue(v, _line, _col) => {
+                    assert_eq!(v, "green.");
                 }
                 _ => panic!("unexpected error: {:?}", err),
             }
+        }
+    }
+
+    #[test]
+    fn test_decimal_attr_values() {
+        let ctx = CompilationCtx::default();
+        let tz = super::tokenize_str("define alien as user with speed:123.4.", &ctx).unwrap();
+        assert_eq!(tz.tokens[5].tt, tuple_from_strs("speed", "123.4"));
+
+        // Not valid decimals: multiple dots, unquoted dot mixed with quoting.
+        for zpl in [
+            "define alien as user with version:1.2.3.",
+            "define alien as user with colors:{'green'.blue}.",
+        ] {
+            let err = super::tokenize_str(zpl, &ctx).unwrap_err();
+            assert!(matches!(
+                err,
+                super::CompilationError::IllegalNumericValue(_, _, _)
+            ));
         }
     }
 

--- a/src/zplstr.rs
+++ b/src/zplstr.rs
@@ -89,12 +89,35 @@ impl fmt::Display for ZPLStr {
     }
 }
 
+struct AttributeValue {
+    value: String,
+    is_quoted: bool,
+    has_unquoted_dot: bool,
+}
+
+impl AttributeValue {
+    pub fn new() -> Self {
+        AttributeValue {
+            value: String::new(),
+            is_quoted: false,
+            has_unquoted_dot: false,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.value.clear();
+        self.is_quoted = false;
+        self.has_unquoted_dot = false;
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.value.is_empty()
+    }
+}
 pub struct ZPLStrBuilder {
     name: String,
-    current_value: String,
-    current_value_is_quoted: bool,
-    current_value_has_unquoted_dot: bool,
-    prev_values: Vec<(String, bool, bool)>,
+    current_value: AttributeValue,
+    prev_values: Vec<AttributeValue>,
     tuple: bool,
     input_to_value: bool,
 }
@@ -103,9 +126,7 @@ impl ZPLStrBuilder {
     pub fn new() -> Self {
         ZPLStrBuilder {
             name: String::new(),
-            current_value: String::new(),
-            current_value_is_quoted: false,
-            current_value_has_unquoted_dot: false,
+            current_value: AttributeValue::new(),
             prev_values: Vec::new(),
             tuple: false,
             input_to_value: false,
@@ -130,11 +151,11 @@ impl ZPLStrBuilder {
                 return Err(CompilationError::IllegalStringLiteralChar(c, line, col));
             }
             if quoted {
-                self.current_value_is_quoted = true;
+                self.current_value.is_quoted = true;
             } else if c == '.' {
-                self.current_value_has_unquoted_dot = true;
+                self.current_value.has_unquoted_dot = true;
             }
-            self.current_value.push(c);
+            self.current_value.value.push(c);
         } else {
             // The name part of a tuple is allowed to contain periods without needing quotes.
             if !quoted && !c.is_ascii_alphanumeric() && !matches!(c, '.' | '-' | '_') {
@@ -166,20 +187,18 @@ impl ZPLStrBuilder {
             panic!("not in value mode");
         }
         if !self.current_value.is_empty() {
-            self.prev_values.push((
-                self.current_value.clone(),
-                self.current_value_is_quoted,
-                self.current_value_has_unquoted_dot,
-            ));
+            self.prev_values.push(AttributeValue {
+                value: self.current_value.value.clone(),
+                is_quoted: self.current_value.is_quoted,
+                has_unquoted_dot: self.current_value.has_unquoted_dot,
+            });
             self.current_value.clear();
-            self.current_value_is_quoted = false;
-            self.current_value_has_unquoted_dot = false;
         }
     }
 
     /// TRUE if the current value being built is empty.
     pub fn value_is_empty(&self) -> bool {
-        self.current_value.is_empty()
+        self.current_value.value.is_empty()
     }
 
     pub fn is_tuple(&self) -> bool {
@@ -199,21 +218,27 @@ impl ZPLStrBuilder {
         if self.tuple {
             let mut vals = self.prev_values;
             if !self.current_value.is_empty() {
-                vals.push((
-                    self.current_value,
-                    self.current_value_is_quoted,
-                    self.current_value_has_unquoted_dot,
-                ));
+                vals.push(AttributeValue {
+                    value: self.current_value.value,
+                    is_quoted: self.current_value.is_quoted,
+                    has_unquoted_dot: self.current_value.has_unquoted_dot,
+                });
             }
             // Unquoted values containing a '.' must be valid decimal numbers.
-            for (v, quoted, unquoted_dot) in &vals {
-                if *unquoted_dot && (*quoted && v.contains('.') || !Self::is_decimal(v)) {
-                    return Err(CompilationError::IllegalNumericValue(v.clone(), line, col));
+            for v in &vals {
+                if v.has_unquoted_dot
+                    && (v.is_quoted && v.value.contains('.') || !Self::is_decimal(&v.value))
+                {
+                    return Err(CompilationError::IllegalNumericValue(
+                        v.value.clone(),
+                        line,
+                        col,
+                    ));
                 }
             }
             return Ok(ZPLStr::tuple(
                 self.name,
-                vals.into_iter().map(|(v, _, _)| v).collect(),
+                vals.into_iter().map(|v| v.value).collect(),
             ));
         }
         Ok(ZPLStr::atom(self.name))

--- a/src/zplstr.rs
+++ b/src/zplstr.rs
@@ -92,7 +92,9 @@ impl fmt::Display for ZPLStr {
 pub struct ZPLStrBuilder {
     name: String,
     current_value: String,
-    prev_values: Vec<String>,
+    current_value_is_quoted: bool,
+    current_value_has_unquoted_dot: bool,
+    prev_values: Vec<(String, bool, bool)>,
     tuple: bool,
     input_to_value: bool,
 }
@@ -102,6 +104,8 @@ impl ZPLStrBuilder {
         ZPLStrBuilder {
             name: String::new(),
             current_value: String::new(),
+            current_value_is_quoted: false,
+            current_value_has_unquoted_dot: false,
             prev_values: Vec::new(),
             tuple: false,
             input_to_value: false,
@@ -122,8 +126,13 @@ impl ZPLStrBuilder {
         col: usize,
     ) -> Result<(), CompilationError> {
         if self.input_to_value {
-            if !quoted && !c.is_ascii_alphanumeric() && !matches!(c, '-' | '_') {
+            if !quoted && !c.is_ascii_alphanumeric() && !matches!(c, '.' | '-' | '_') {
                 return Err(CompilationError::IllegalStringLiteralChar(c, line, col));
+            }
+            if quoted {
+                self.current_value_is_quoted = true;
+            } else if c == '.' {
+                self.current_value_has_unquoted_dot = true;
             }
             self.current_value.push(c);
         } else {
@@ -157,8 +166,14 @@ impl ZPLStrBuilder {
             panic!("not in value mode");
         }
         if !self.current_value.is_empty() {
-            self.prev_values.push(self.current_value.clone());
+            self.prev_values.push((
+                self.current_value.clone(),
+                self.current_value_is_quoted,
+                self.current_value_has_unquoted_dot,
+            ));
             self.current_value.clear();
+            self.current_value_is_quoted = false;
+            self.current_value_has_unquoted_dot = false;
         }
     }
 
@@ -180,18 +195,39 @@ impl ZPLStrBuilder {
     }
 
     /// Convert this builder into a [ZPLStr].
-    pub fn build(self) -> ZPLStr {
+    pub fn build(self, line: usize, col: usize) -> Result<ZPLStr, CompilationError> {
         if self.tuple {
             let mut vals = self.prev_values;
             if !self.current_value.is_empty() {
-                vals.push(self.current_value);
+                vals.push((
+                    self.current_value,
+                    self.current_value_is_quoted,
+                    self.current_value_has_unquoted_dot,
+                ));
             }
-            return ZPLStr::tuple(self.name, vals);
+            // Unquoted values containing a '.' must be valid decimal numbers.
+            for (v, quoted, unquoted_dot) in &vals {
+                if *unquoted_dot && (*quoted && v.contains('.') || !Self::is_decimal(v)) {
+                    return Err(CompilationError::IllegalNumericValue(v.clone(), line, col));
+                }
+            }
+            return Ok(ZPLStr::tuple(
+                self.name,
+                vals.into_iter().map(|(v, _, _)| v).collect(),
+            ));
         }
-        ZPLStr::atom(self.name)
+        Ok(ZPLStr::atom(self.name))
+    }
+    /// Checks if the supplied value is a decimal number: digits, '.', digits.
+    fn is_decimal(v: &str) -> bool {
+        v.split_once('.').is_some_and(|(whole, frac)| {
+            !whole.is_empty()
+                && !frac.is_empty()
+                && whole.chars().all(|c| c.is_ascii_digit())
+                && frac.chars().all(|c| c.is_ascii_digit())
+        })
     }
 }
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -208,7 +244,7 @@ mod test {
         assert!(!b.is_empty());
         assert!(!b.is_tuple());
         assert!(!b.is_sugar());
-        let s = b.build();
+        let s = b.build(1, 1).unwrap();
         assert_eq!(s.is_tuple(), false);
         assert_eq!(s.as_atom().unwrap(), "classified");
         assert_eq!(format!("{}", s), "classified");
@@ -229,7 +265,7 @@ mod test {
         assert!(b.accept_value().is_ok());
         assert!(b.accept_value().is_err()); // second time should return false
         assert!(b.is_tuple());
-        let s = b.build();
+        let s = b.build(1, 1).unwrap();
         assert_eq!(s.is_tuple(), true);
         let (k, v) = s.as_tuple().unwrap();
         assert_eq!(k, "name");
@@ -255,7 +291,7 @@ mod test {
         for (i, c) in "John".chars().enumerate() {
             b.push(c, false, 1, i + 1).unwrap();
         }
-        let s = b.build();
+        let s = b.build(1, 1).unwrap();
         assert_eq!(s.is_tuple(), true);
         let (k, v) = s.as_tuple().unwrap();
         assert_eq!(k, "name");
@@ -290,7 +326,7 @@ mod test {
         for (i, c) in "role3".chars().enumerate() {
             b.push(c, false, 1, i + 1).unwrap();
         }
-        let s = b.build();
+        let s = b.build(1, 1).unwrap();
         assert_eq!(s.is_tuple(), true);
         let (k, v) = s.as_tuple().unwrap();
         assert_eq!(k, "roles");
@@ -299,5 +335,15 @@ mod test {
         assert_eq!(v[1], "role2");
         assert_eq!(v[2], "role3");
         assert_eq!(format!("{}", s), "roles:{role1, role2, role3}");
+    }
+
+    #[test]
+    fn test_is_decimal() {
+        for v in ["1.5", "123.4", "0.0"] {
+            assert!(ZPLStrBuilder::is_decimal(v), "{}", v);
+        }
+        for v in [".5", "5.", "1.2.3", "-1.5", "1.a", "green.blue", "5"] {
+            assert!(!ZPLStrBuilder::is_decimal(v), "{}", v);
+        }
     }
 }

--- a/zpl.bnf
+++ b/zpl.bnf
@@ -177,15 +177,20 @@
 
 <value> ::= <unquoted-value> | <quoted-string> | <value-set>
 
-// Unlike names, unquoted values may NOT contain "." -- so an unquoted float
-// is invalid in value position ("version:1.5" is an error; quote it:
-// "version:'1.5'"). Integers are fine ("level:7").
+// Unlike names, an unquoted value may contain "." ONLY when the entire value
+// is a decimal number: digits, ".", digits. Anything else
+// with an unquoted dot is an error. Integers are fine ("level:7"),
+// A value that mixes quoted segments with an unquoted dot is also an error ("'1'.5").
 //
 // SPEC DIVERGENCE: ZRFC 15 says unquoted "sequences of numerals with an
-// optional decimal point" are valid strings anywhere, i.e. floats like 123.4
-// should be usable as attribute values. The compiler only accepts them in
-// name position, not after ':' (unless quoted).
-<unquoted-value> ::= <value-char>+
+// optional decimal point" are valid strings anywhere. The compiler now
+// accepts floats in value position, but requires digits on both sides of
+// the dot ("123.4")
+<unquoted-value> ::= <value-word> | <decimal-number>
+
+<value-word> ::= <value-char>+
+
+<decimal-number> ::= <digit>+ "." <digit>+
 
 <value-char> ::= <letter> | <digit> | "-" | "_"
 


### PR DESCRIPTION
Edited the compiler to allow floating points that are unquoted as attribute values. It was difficult to figure out exactly how to do this with the current implementation but I think I found a pretty good solution by updating the ZPLStrBuilder struct to track quoted characters and unquoted dots and then a function that checks floating point form on values. This ensures that a value could be something like 1.2, but if a dot appears in a non-numeric value like green.blue it won't allow it. Quoted values like 'green.blue' still work like before, and only exact numbersforms are accepted (1.2.3, .5, and 5. are all rejected). If you think there is a better way to do this let me know and I am happy to change or keep brainstorming ideas. 