### PR TITLE
made class names case insensitive

### DIFF
--- a/src/allow.rs
+++ b/src/allow.rs
@@ -309,8 +309,7 @@ pub fn parse_allow(
     for client_clause in &mut ac.client {
         for attr in &mut client_clause.with {
             if attr.is_unspecified_domain() {
-                let canonical_class_name = classes_idx.get(&client_clause.class).unwrap();
-                let flavor = classes_map.get(canonical_class_name).unwrap().flavor;
+                let flavor = classes_map.get(&client_clause.class).unwrap().flavor;
                 attr.set_domain(flavor.into());
             }
         }
@@ -318,8 +317,7 @@ pub fn parse_allow(
     for server_clause in &mut ac.server {
         for attr in &mut server_clause.with {
             if attr.is_unspecified_domain() {
-                let canonical_class_name = classes_idx.get(&server_clause.class).unwrap();
-                let flavor = classes_map.get(canonical_class_name).unwrap().flavor;
+                let flavor = classes_map.get(&server_clause.class).unwrap().flavor;
                 attr.set_domain(flavor.into());
             }
         }
@@ -540,7 +538,7 @@ where
 fn parse_allow_signal_clause<'a, I>(
     pa_state: &mut ParseAllowState,
     tokens: &mut Peekable<I>,
-    _classes_idx: &HashMap<String, String>,
+    classes_idx: &HashMap<String, String>,
     classes_map: &HashMap<String, Class>,
 ) -> Result<Token, CompilationError>
 where
@@ -595,7 +593,10 @@ where
         // The service does not share a name with a reserved keyword
         if let TokenType::Literal(ref service_name) = tok.tt {
             // We require the requested service to exist in the list of services
-            target = if let Some(service_class) = classes_map.get(service_name) {
+            target = if let Some(service_class) = classes_idx
+                .get(&service_name.to_lowercase())
+                .and_then(|cn| classes_map.get(cn))
+            {
                 if service_class.flavor != ClassFlavor::Service {
                     return Err(CompilationError::ParseError(
                         format!(
@@ -777,7 +778,7 @@ impl PState {
                 }
                 TokenType::Literal(s) => {
                     // This could be a class name or a tag name.
-                    if let Some(class) = classes.get(s) {
+                    if let Some(class) = classes.get(&s.to_lowercase()) {
                         if self.class_name.is_some() {
                             // We already have a class name.
                             let tok = tokens.next().unwrap();
@@ -854,8 +855,8 @@ mod test {
         }
         let mut class_index: HashMap<String, String> = HashMap::new();
         for (name, class) in classes.iter() {
-            class_index.insert(name.clone(), name.clone());
-            class_index.insert(class.aka.clone(), name.clone());
+            class_index.insert(name.to_lowercase(), name.clone());
+            class_index.insert(class.aka.to_lowercase(), name.clone());
         }
         (class_index, classes)
     }
@@ -878,8 +879,8 @@ mod test {
         }
         let mut class_index: HashMap<String, String> = HashMap::new();
         for (name, class) in classes.iter() {
-            class_index.insert(name.clone(), name.clone());
-            class_index.insert(class.aka.clone(), name.clone());
+            class_index.insert(name.to_lowercase(), name.clone());
+            class_index.insert(class.aka.to_lowercase(), name.clone());
         }
 
         let cctx = CompilationCtx::default();
@@ -918,8 +919,8 @@ mod test {
         }
         let mut class_index: HashMap<String, String> = HashMap::new();
         for (name, class) in classes.iter() {
-            class_index.insert(name.clone(), name.clone());
-            class_index.insert(class.aka.clone(), name.clone());
+            class_index.insert(name.to_lowercase(), name.clone());
+            class_index.insert(class.aka.to_lowercase(), name.clone());
         }
 
         let cctx = CompilationCtx::default();
@@ -951,8 +952,8 @@ mod test {
         }
         let mut class_index: HashMap<String, String> = HashMap::new();
         for (name, class) in classes.iter() {
-            class_index.insert(name.clone(), name.clone());
-            class_index.insert(class.aka.clone(), name.clone());
+            class_index.insert(name.to_lowercase(), name.clone());
+            class_index.insert(class.aka.to_lowercase(), name.clone());
         }
 
         let cctx = CompilationCtx::default();
@@ -1002,8 +1003,8 @@ mod test {
         }
         let mut class_index: HashMap<String, String> = HashMap::new();
         for (name, class) in classes.iter() {
-            class_index.insert(name.clone(), name.clone());
-            class_index.insert(class.aka.clone(), name.clone());
+            class_index.insert(name.to_lowercase(), name.clone());
+            class_index.insert(class.aka.to_lowercase(), name.clone());
         }
 
         let cctx = CompilationCtx::default();
@@ -1048,8 +1049,8 @@ mod test {
         }
         let mut class_index: HashMap<String, String> = HashMap::new();
         for (name, class) in classes.iter() {
-            class_index.insert(name.clone(), name.clone());
-            class_index.insert(class.aka.clone(), name.clone());
+            class_index.insert(name.to_lowercase(), name.clone());
+            class_index.insert(class.aka.to_lowercase(), name.clone());
         }
 
         let cctx = CompilationCtx::default();
@@ -1116,8 +1117,8 @@ mod test {
         }
         let mut class_index: HashMap<String, String> = HashMap::new();
         for (name, class) in classes.iter() {
-            class_index.insert(name.clone(), name.clone());
-            class_index.insert(class.aka.clone(), name.clone());
+            class_index.insert(name.to_lowercase(), name.clone());
+            class_index.insert(class.aka.to_lowercase(), name.clone());
         }
 
         let cctx = CompilationCtx::default();
@@ -1194,8 +1195,8 @@ mod test {
         }
         let mut class_index: HashMap<String, String> = HashMap::new();
         for (name, class) in classes.iter() {
-            class_index.insert(name.clone(), name.clone());
-            class_index.insert(class.aka.clone(), name.clone());
+            class_index.insert(name.to_lowercase(), name.clone());
+            class_index.insert(class.aka.to_lowercase(), name.clone());
         }
 
         let cctx = CompilationCtx::default();

--- a/src/define.rs
+++ b/src/define.rs
@@ -66,7 +66,7 @@ pub fn parse_define(
     // The flavor of the parent class really cannot be figured out until all
     // the classes are defined. To give meaning full error may need to track
     // the define token or something.
-    let flavor = match parent_class_name.as_str() {
+    let flavor = match parent_class_name.to_lowercase().as_str() {
         zpl::DEF_CLASS_USER_NAME | zpl::DEF_CLASS_USER_AKA => {
             parent_class_name = String::from(zpl::DEF_CLASS_USER_NAME);
             ClassFlavor::User
@@ -309,6 +309,10 @@ where
 // Fill in any classes with undefined flavor by walking backwards to their parent classes.
 pub fn resolve_class_flavors(classes: &mut HashMap<String, Class>) -> Result<(), CompilationError> {
     let mut undef_count = 0;
+    let lowercase_classes: HashMap<String, String> = classes
+        .keys()
+        .map(|k| (k.to_lowercase(), k.clone()))
+        .collect();
     for class in (*classes).values() {
         if class.flavor == ClassFlavor::Undefined {
             undef_count += 1;
@@ -324,7 +328,10 @@ pub fn resolve_class_flavors(classes: &mut HashMap<String, Class>) -> Result<(),
         }
         for name in needs_parent {
             let parentless_ref = classes.get(&name).unwrap();
-            let parent_flavor = match classes.get(parentless_ref.parent.as_str()) {
+            let canonical_parent = lowercase_classes
+                .get(&parentless_ref.parent.to_lowercase())
+                .cloned();
+            let parent_flavor = match canonical_parent.as_ref().and_then(|k| classes.get(k)) {
                 Some(parent) => {
                     // Ensure parent allows subclassing.
                     if !parent.extensible {
@@ -354,6 +361,7 @@ pub fn resolve_class_flavors(classes: &mut HashMap<String, Class>) -> Result<(),
             if parent_flavor != ClassFlavor::Undefined {
                 let parentless = classes.get_mut(&name).unwrap();
                 parentless.flavor = parent_flavor;
+                parentless.parent = canonical_parent.unwrap();
                 undef_count -= 1;
             }
         }

--- a/src/never.rs
+++ b/src/never.rs
@@ -57,8 +57,8 @@ mod test {
         }
         let mut class_index: HashMap<String, String> = HashMap::new();
         for (name, class) in classes.iter() {
-            class_index.insert(name.clone(), name.clone());
-            class_index.insert(class.aka.clone(), name.clone());
+            class_index.insert(name.to_lowercase(), name.clone());
+            class_index.insert(class.aka.to_lowercase(), name.clone());
         }
         (class_index, classes)
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -78,8 +78,8 @@ pub fn parse(tokens: Vec<Token>, ctx: &CompilationCtx) -> Result<ParsingResult, 
     // Construct an index that adds entries for all the AKAs.
     let mut class_index: HashMap<String, String> = HashMap::new();
     for (name, class) in classes.iter() {
-        class_index.insert(name.clone(), name.clone());
-        class_index.insert(class.aka.clone(), name.clone());
+        class_index.insert(name.to_lowercase(), name.clone());
+        class_index.insert(class.aka.to_lowercase(), name.clone());
     }
 
     // Define statements create classes.
@@ -88,7 +88,7 @@ pub fn parse(tokens: Vec<Token>, ctx: &CompilationCtx) -> Result<ParsingResult, 
             let class = parse_define(statement, i + 1)?;
 
             // It is an error to redefine a class.
-            if classes.contains_key(&class.name) || class_index.contains_key(&class.name) {
+            if class_index.contains_key(&class.name.to_lowercase()) {
                 return Err(CompilationError::Redefinition(
                     class.name,
                     statement[0].line,
@@ -96,8 +96,8 @@ pub fn parse(tokens: Vec<Token>, ctx: &CompilationCtx) -> Result<ParsingResult, 
                 ));
             }
             let cname = class.name.clone();
-            class_index.insert(cname.clone(), cname.clone());
-            class_index.insert(class.aka.clone(), cname.clone());
+            class_index.insert(cname.to_lowercase(), cname.clone());
+            class_index.insert(class.aka.to_lowercase(), cname.clone());
             classes.insert(cname, class);
         }
     }
@@ -524,6 +524,35 @@ allow marketing-emps to access role:marketing services
         let tz = tokenize_str(input, &ctx).unwrap();
         match parse(tz.tokens, &ctx) {
             Ok(_) => panic!("should have failed: class defined twice"),
+            Err(e) => assert!(
+                matches!(e, CompilationError::Redefinition(_, _, _)),
+                "unexpected error: {e:?}"
+            ),
+        }
+    }
+
+    // Class names match case-insensitively. A miscased reference in an
+    // allow statement resolves to the class (not a tag), and a define whose name
+    // differs from an existing class only by case is a redefinition.
+    #[test]
+    fn test_class_name_case_insensitive() {
+        let ctx = CompilationCtx::default();
+
+        let input = "define employee as a user with id\nallow EMPLOYEES to access services";
+        let tz = tokenize_str(input, &ctx).unwrap();
+        let pr = parse(tz.tokens, &ctx).expect("should parse");
+        let user_clause = pr.policy.allows[0]
+            .client
+            .iter()
+            .find(|c| c.flavor == ClassFlavor::User)
+            .expect("user clause missing from LHS");
+        assert_eq!(user_clause.class, "employee");
+        assert!(user_clause.with.is_empty(), "'EMPLOYEES' must not be a tag");
+
+        let input = "define employee as a user with id \n define Employee as a user with id";
+        let tz = tokenize_str(input, &ctx).unwrap();
+        match parse(tz.tokens, &ctx) {
+            Ok(_) => panic!("should have failed: class redefined with different case"),
             Err(e) => assert!(
                 matches!(e, CompilationError::Redefinition(_, _, _)),
                 "unexpected error: {e:?}"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -86,14 +86,14 @@ pub fn parse(tokens: Vec<Token>, ctx: &CompilationCtx) -> Result<ParsingResult, 
     for (i, statement) in statements.iter().enumerate() {
         if statement[0].tt == TokenType::Define {
             let class = parse_define(statement, i + 1)?;
-
-            // It is an error to redefine a class.
-            if class_index.contains_key(&class.name.to_lowercase()) {
-                return Err(CompilationError::Redefinition(
-                    class.name,
-                    statement[0].line,
-                    statement[0].col,
-                ));
+            for new_name in [&class.name, &class.aka] {
+                if class_index.contains_key(&new_name.to_lowercase()) {
+                    return Err(CompilationError::Redefinition(
+                        new_name.clone(),
+                        statement[0].line,
+                        statement[0].col,
+                    ));
+                }
             }
             let cname = class.name.clone();
             class_index.insert(cname.to_lowercase(), cname.clone());
@@ -553,6 +553,21 @@ allow marketing-emps to access role:marketing services
         let tz = tokenize_str(input, &ctx).unwrap();
         match parse(tz.tokens, &ctx) {
             Ok(_) => panic!("should have failed: class redefined with different case"),
+            Err(e) => assert!(
+                matches!(e, CompilationError::Redefinition(_, _, _)),
+                "unexpected error: {e:?}"
+            ),
+        }
+    }
+
+    // An AKA colliding with an existing name/AKA must be a Redefinition error,
+    #[test]
+    fn test_aka_collision_error() {
+        let input = "define bad AKA Users as endpoint";
+        let ctx = CompilationCtx::default();
+        let tz = tokenize_str(input, &ctx).unwrap();
+        match parse(tz.tokens, &ctx) {
+            Ok(_) => panic!("should have failed: AKA collides with built-in 'users'"),
             Err(e) => assert!(
                 matches!(e, CompilationError::Redefinition(_, _, _)),
                 "unexpected error: {e:?}"

--- a/zpl.bnf
+++ b/zpl.bnf
@@ -22,13 +22,8 @@
 // KEYWORD STATE (from lex.rs):
 //   - Active keywords: never, allow, define, with, to, access, and, as, aka,
 //     tag, tags, on, optional, multiple, signal (plus "," as AND, "." as terminator).
-//   - Keywords are case-insensitive ("ALLOW" == "allow"). Literals (class,
+//   - Keywords are case-insensitive ("ALLOW" == "allow"). Literals except class names (class,
 //     attribute, and value names) are case-sensitive.
-//   - SPEC DIVERGENCE: ZRFC 15 permits only three keyword casings (lowercase,
-//     Initial-capital, ALLCAPS) — the compiler accepts any mix ("aLLoW").
-//     ZRFC 15 also says class names are case-INsensitive and reserves "all
-//     English prepositions that are not keywords"; the compiler matches class
-//     names case-sensitively.
 //   - "a"/"an" are dropped as syntactic sugar wherever they appear (not just after "as").
 //   - "link", "links", "over" are NOT tokenized; if written they parse as ordinary
 //     literals. ZRFC 15 uses them for the link class and "over" clause (see above),
@@ -62,16 +57,14 @@
 
 // The "and"/"," before "signal" are optional delimiters (consumed but not required).
 // The message may be any <name> (quoting is conventional but not required).
-// The target must be the CANONICAL name of a service class: either the built-in
-// "service" (not "services") or the name a class was defined with. AKA/plural
-// forms are NOT accepted here (allow.rs looks the target up in the canonical
-// class map only). Nothing may follow the signal clause.
-<signal-clause> ::= ","? "and"? "signal" <name> "to" <canonical-service-class-name>
+// The target must be an existing service class, referenced like any other class
+// reference: canonical name or AKA/plural, matched case-insensitively. Nothing
+// may follow the signal clause.
+<signal-clause> ::= ","? "and"? "signal" <name> "to" <service-class-name>
 
 // Every defined class gets an AKA: the explicit one, or an auto-pluralized (appending "s" or "es", putile::pluralize)
 // form of its name ("employee" -> "employees", "box" -> "boxes"). Class references in allow/never
-// statements accept either the canonical name or the AKA (except the signal
-// target, see <signal-clause>).
+// statements accept either the canonical name or the AKA.
 //
 // SPEC DIVERGENCE: ZRFC 15 says an explicit
 // AKA is an ADDITIONAL synonym (both "mouses" and "mice" work). In the compiler an explicit AKA
@@ -120,10 +113,6 @@
 <service-spec> ::= (<attribute-expr> | <service-class-name>) (<and-token>? (<attribute-expr> | <service-class-name>))*
 // A <service-class-name> must be, or descend from, the built-in "service" class.
 <service-class-name> ::= <name> | <built-in-service-class-name>
-
-// Canonical form only: the built-in "service" or the name given in a define
-// statement -- never an AKA/plural. Used by <signal-clause>.
-<canonical-service-class-name> ::= "service" | <name>
 
 <attribute-expr> ::= <attr-tag> | <attr-kv-pair> | <attr-key-presence>
 


### PR DESCRIPTION
Compiler now sees class names as case insensitive. Class names and AKAs are inserted into classes_idx with lowercased keys, and lookups lowercase the queried name, so any casing of a class name or its AKA returns the class's defined name