### PR TITLE
ability to set provider addr

### DIFF
--- a/README_ZPLC.md
+++ b/README_ZPLC.md
@@ -33,7 +33,7 @@ same address.
 
 ### Topology
 
-If there are multiple nodes you need to define their substrate addresses. We support multiple 
+If there are multiple nodes you need to define their substrate addresses. We support multiple
 substrate addresses per node. Each address is specified in `HOST:PORT` format and is tied
 to an identifier.  In the example below the identifier is `i0`.
 
@@ -52,7 +52,7 @@ To connect nodes you must specific `links` in the zplc file.
 ```toml
 [links.<LINKID>]
 attributes = [["zpr.cost", "1"]] # this is the default
-peers = [ { node = "<NODEID>" }, 
+peers = [ { node = "<NODEID>" },
           { node = "<NODEID>" } ]
 ```
 
@@ -62,7 +62,7 @@ in the peers list, eg:
 ```toml
 [links.<LINKID>]
 attributes = [["zpr.cost", "1"]] # this is the default
-peers = [ { node = "<NODEID>" }, 
+peers = [ { node = "<NODEID>" },
           { node = "<NODEID>", interface = "i3" } ]
 ```
 
@@ -113,7 +113,7 @@ For non default trusted services, the field meanings are:
   the compiler expects to find a service block named `<TSNAME>-client`.
 * `cert_path` - Used to pass a TLS certificate to the visa service which is used to
   verify the service connection.
-* `returns_attributes` - List of attribute keys returned by the service mapped to 
+* `returns_attributes` - List of attribute keys returned by the service mapped to
   ZPL attribute names.
 * `identity_attributes` - Subset of the `returns_attributes` that denote identity.
 * `provider` - Attribute key/value tuples of the actor (or actors) that provide this service.
@@ -181,7 +181,7 @@ returns_attributes = [
 ]
 ```
 
-And then for `identity_attributes` make sure to use the service name (not the 
+And then for `identity_attributes` make sure to use the service name (not the
 ZPL name).  For example, given the above returns attributes:
 
 ```toml
@@ -257,8 +257,29 @@ l4protocl = "TCP"
 port = 443
 
 [service.WebService]
-protocol = webtls
+protocol = "webtls"
 port = 3030
+```
+
+To associate a service with an actor you need provider attributes. These can
+come from the ZPL, but you can also put them in the configuration.  Eg,
+
+```toml
+[service.WebService]
+protocol = "http"
+port = 80
+provider = [[ "endpoint.zpr.adapter.cn", "foo.blah"]]
+```
+
+If you need a static address for a service, the service adapter needs to specify
+a `zpr_addr` in its config file AND the service configuration needs to match
+with a `zpr.addr` attribute.  For example,
+
+```toml
+[service.WebService]
+protocol = "http"
+port = 80
+provider = [[ "endpoint.zpr.adapter.cn", "foo.blah"], ["zpr.addr", "fd5a:5052:2020::19"]]
 ```
 
 

--- a/src/fabric_util.rs
+++ b/src/fabric_util.rs
@@ -12,7 +12,16 @@ use zpr::policy_types::{AttrDomain, Attribute};
 pub fn vec_to_attributes(v: &[(String, String)]) -> Result<Vec<Attribute>, CompilationError> {
     let mut attrs = Vec::new();
     for (k, v) in v {
-        attrs.push(Attribute::tuple(k).single().value(v).build()?);
+        // `zpr.addr` lives in the ZPR-internal domain, which parse_domain rejects.
+        // Route it through the internal constructor so it can appear in a provider clause.
+        // This is currently how we assign a static address to a service.
+        // Will need to be rethought in the future - see https://github.com/org-zpr/zpr-compiler/issues/133
+        let attr = if k == crate::zpl::KATTR_ADDR {
+            Attribute::try_zpr_internal_attr(k, v)?
+        } else {
+            Attribute::tuple(k).single().value(v).build()?
+        };
+        attrs.push(attr);
     }
     Ok(attrs)
 }
@@ -33,6 +42,23 @@ pub fn vec_to_attributes_in_domain(
         );
     }
     Ok(attrs)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_zpr_addr_allowed_but_other_internal_rejected() {
+        // zpr.addr is permitted and lands in the ZPR-internal domain.
+        let ok = vec_to_attributes(&[("zpr.addr".to_string(), "fd5a:5052:8888::9".to_string())])
+            .expect("zpr.addr should be allowed");
+        assert_eq!(ok.len(), 1);
+        assert_eq!(ok[0].zpl_key(), "zpr.addr");
+
+        // Other zpr.* keys still fail the domain check (no spoofing internal attrs).
+        assert!(vec_to_attributes(&[("zpr.role".to_string(), "node".to_string())]).is_err());
+    }
 }
 
 /// Given a list of attributes that apply, return just the set of unique

--- a/src/weaver.rs
+++ b/src/weaver.rs
@@ -527,6 +527,14 @@ impl Weaver {
                     self.wctx
                         .add_used_trusted_service(zpl::DEFAULT_TRUSTED_SERVICE_ID);
                 }
+                // zpr.addr is a compiler-internal attribute vouched for by the default
+                // trusted service, not something an external service reports.
+                // See https://github.com/org-zpr/zpr-compiler/issues/133
+                zpl::KATTR_ADDR => {
+                    resolved_attrs.push(zpl_attr.clone());
+                    self.wctx
+                        .add_used_trusted_service(zpl::DEFAULT_TRUSTED_SERVICE_ID);
+                }
                 _ => {
                     // TODO: This should be cached
                     // TODO: Not sure we are handling the case where ZPL is using prefixes correctly here.
@@ -1518,5 +1526,40 @@ mod test {
         let id_attrs = fsvc.identity_attrs.as_ref().unwrap();
         assert_eq!(id_attrs.len(), 1);
         assert!(id_attrs.contains(&String::from("id")));
+    }
+
+    #[test]
+    fn test_resolve_attributes_allows_zpr_addr() {
+        // zpr.addr is a compiler-internal attribute; it should resolve without
+        // appearing in any trusted service's returns_attributes.
+        let cfg = r#"
+        [nodes.n0]
+        zpr_address = "fd5a:5052:90de::1"
+        provider = [["endpoint.zpr.adapter.cn", "fee"]]
+
+        [trusted_services.bas]
+        api = "validation/2"
+        provider = [["endpoint.zpr.adapter.cn", "fee"]]
+        returns_attributes = ["id -> user.id"]
+        "#;
+
+        let ctx = CompilationCtx::default();
+        let config = ConfigApi::new_from_toml_content(&cfg, &env::temp_dir(), &ctx)
+            .expect("failed to parse config");
+
+        let mut w = Weaver::new(WeavingContext::default());
+        let addr = Attribute::try_zpr_internal_attr(zpl::KATTR_ADDR, "fd5a:5052:8888::8")
+            .expect("failed to build zpr.addr attribute");
+
+        let resolved = w
+            .resolve_attributes(&[addr], &config)
+            .expect("zpr.addr should resolve");
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].zpl_key(), zpl::KATTR_ADDR);
+        assert!(
+            w.wctx
+                .used_trusted_services
+                .contains(zpl::DEFAULT_TRUSTED_SERVICE_ID)
+        );
     }
 }


### PR DESCRIPTION
In the service configuration you can set "zpr.addr" attribute to assign/confirm a static address on a service.