### PR TITLE
Ic/utf8 strings

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -108,4 +108,7 @@ pub enum CompilationError {
         "'{0}' at line {1}, column {2} is a reserved preposition (ZRFC 15 reserves English prepositions for future language extensions)"
     )]
     ReservedPreposition(String, usize, usize),
+
+    #[error("Illegal charecter following backslash within quote at line {0}, column {1}")]
+    BackslashError(usize, usize),
 }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -195,6 +195,15 @@ enum QuotingType {
     Double,
 }
 
+//single and double quote types
+const SINGLE_QUOTES: [char; 5] = ['\'', '`', '´', '‘', '’'];
+const DOUBLE_QUOTES: [char; 3] = ['\"', '“', '”'];
+
+/// verifies quote types
+fn is_quote_char(c: char) -> bool {
+    SINGLE_QUOTES.contains(&c) || DOUBLE_QUOTES.contains(&c)
+}
+
 impl QuotingType {
     fn is_quoting(&self) -> bool {
         match self {
@@ -205,18 +214,20 @@ impl QuotingType {
 
     /// Panics if not called with a valid quote character.
     fn set_quoting(&mut self, c: char) {
-        match c {
-            '\'' | '`' => *self = QuotingType::Single,
-            '\"' => *self = QuotingType::Double,
-            _ => panic!("call to set_quoting with invalid char: '{c}'"),
+        if SINGLE_QUOTES.contains(&c) {
+            *self = QuotingType::Single
+        } else if DOUBLE_QUOTES.contains(&c) {
+            *self = QuotingType::Double
+        } else {
+            panic!("call to set_quoting with invalid char: '{c}'")
         }
     }
 
     fn is_match(&self, c: char) -> bool {
         match self {
             QuotingType::None => false,
-            QuotingType::Single => c == '\'' || c == '`',
-            QuotingType::Double => c == '\"',
+            QuotingType::Single => SINGLE_QUOTES.contains(&c),
+            QuotingType::Double => DOUBLE_QUOTES.contains(&c),
         }
     }
 }
@@ -457,7 +468,7 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                 }
                 col += 1;
             }
-            '\'' | '`' | '\"' => {
+            c if is_quote_char(c) => {
                 // A single or double quote alone can start a quoted string.
                 // We do not differentiate between the types of single quotes. But
                 // if a single quote starts a quoted string a single quote must end it
@@ -532,9 +543,13 @@ pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, Com
                 if quoting.is_quoting() {
                     // If we are quoting, we need to escape (ie, accept) the next character.
                     if let Some(&next) = chars.peek() {
-                        col += 1;
-                        let _ = chars.next(); // consume the next char
-                        current_word.push(next, true, line, col)?;
+                        if is_quote_char(next) || next == '\\' {
+                            col += 1;
+                            let _ = chars.next(); // consume the next char
+                            current_word.push(next, true, line, col)?;
+                        } else {
+                            return Err(CompilationError::BackslashError(line, col));
+                        }
                     } else {
                         // trailing backslash while quoting?
                         // Don't care -- we will get an error due to EOL while quoting.

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -619,6 +619,29 @@ mod test {
     }
 
     #[test]
+    fn test_utf8_and_quote_variants() {
+        let zpl = "define foo as user with color:pürple, “role”:“man \\” ager”, and tag ‘naïve’";
+        let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
+        let tokens = tz.tokens;
+        println!("{:?}", tokens);
+        assert_eq!(tokens.len(), 12);
+        assert_eq!(tokens[5].tt, tuple_from_strs("color", "pürple"));
+        assert_eq!(tokens[7].tt, tuple_from_strs("role", "man ” ager"));
+        assert_eq!(tokens[11].tt, TokenType::Literal(String::from("naïve")));
+    }
+
+    #[test]
+    fn test_utf8_unquoted_name() {
+        let zpl = "define pürple as user with größe:blau";
+        let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
+        let tokens = tz.tokens;
+        println!("{:?}", tokens);
+        assert_eq!(tokens.len(), 6);
+        assert_eq!(tokens[1].tt, TokenType::Literal(String::from("pürple")));
+        assert_eq!(tokens[5].tt, tuple_from_strs("größe", "blau"));
+    }
+
+    #[test]
     fn test_tuple_literal_sets() {
         let zpl = "define foo as user with colors:{purple,yellow}, `roles`:{`manager`, chef}, office:`fris:co`, and tag `foo bar`";
         let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
@@ -1115,6 +1138,32 @@ mod test {
     fn test_unterminated_quote_eof() {
         // A quoted string that reaches EOF without a closing quote is an error.
         let zpl = "\"unterminated";
+        let tz = super::tokenize_str(zpl, &CompilationCtx::default());
+        assert!(tz.is_err());
+        assert!(matches!(
+            tz.unwrap_err(),
+            super::CompilationError::UnterminatedQuote(_, _)
+        ));
+    }
+
+    // --- Error: bad backslash escape ---
+
+    #[test]
+    fn test_invalid_escape_in_quotes() {
+        let zpl = "define foo as user with tag \"a\\xb\"";
+        let tz = super::tokenize_str(zpl, &CompilationCtx::default());
+        assert!(tz.is_err());
+        assert!(matches!(
+            tz.unwrap_err(),
+            super::CompilationError::BackslashError(_, _)
+        ));
+    }
+
+    // --- Error: quote families don't mix ---
+
+    #[test]
+    fn test_mismatched_quote_families() {
+        let zpl = "define foo as user with tag “abc'";
         let tz = super::tokenize_str(zpl, &CompilationCtx::default());
         assert!(tz.is_err());
         assert!(matches!(

--- a/src/zplstr.rs
+++ b/src/zplstr.rs
@@ -138,7 +138,7 @@ impl ZPLStrBuilder {
     }
 
     /// Push supplied character onto the name or value depending on mode.
-    /// TODO: Currently only accepts ASCII alphanumerics, '-', '_', and '.' (for names).
+    /// Accepts alphanumerics, '-', '_', and '.' (for names).
     pub fn push(
         &mut self,
         c: char,
@@ -147,7 +147,7 @@ impl ZPLStrBuilder {
         col: usize,
     ) -> Result<(), CompilationError> {
         if self.input_to_value {
-            if !quoted && !c.is_ascii_alphanumeric() && !matches!(c, '.' | '-' | '_') {
+            if !quoted && !c.is_alphanumeric() && !matches!(c, '.' | '-' | '_') {
                 return Err(CompilationError::IllegalStringLiteralChar(c, line, col));
             }
             if quoted {
@@ -158,7 +158,7 @@ impl ZPLStrBuilder {
             self.current_value.value.push(c);
         } else {
             // The name part of a tuple is allowed to contain periods without needing quotes.
-            if !quoted && !c.is_ascii_alphanumeric() && !matches!(c, '.' | '-' | '_') {
+            if !quoted && !c.is_alphanumeric() && !matches!(c, '.' | '-' | '_') {
                 return Err(CompilationError::IllegalNameLiteralChar(c, line, col));
             }
             self.name.push(c);

--- a/zpl.bnf
+++ b/zpl.bnf
@@ -216,8 +216,9 @@
 
 <double-quote> ::= '"' | '“' | '”'                
 
-<letter> ::= any Unicode alphabetic character (Rust char::is_alphabetic)
+// In code: Rust's char::is_alphabetic and char::is_numeric.
+<letter> ::= ? Unicode Alphabetic ?
 
-<digit> ::= any Unicode numeric character (Rust char::is_numeric)
+<digit> ::= ? Unicode Number ?
 
 <comment> ::= "#" <any-chars-to-eol> | "//" <any-chars-to-eol>

--- a/zpl.bnf
+++ b/zpl.bnf
@@ -137,7 +137,8 @@
 // dots ('"a b".c' is two separate tokens). A dot followed by whitespace (or
 // EOF) terminates the statement instead. There is no leading-letter rule:
 // digits or a dot may start a name ("9abc", "42", "4.2" are all valid names).
-// Consecutive dots ("foo..bar") only produce a warning. ASCII only.
+// Consecutive dots ("foo..bar") only produce a warning. Unicode alphanumerics
+// are accepted ("pürple", "日本語").
 //
 // SPEC DIVERGENCE: ZRFC 15 describes hierarchical namespaces with a "global"
 // default namespace, namespaces created on first reference in a define, and
@@ -183,26 +184,23 @@
 
 <value-char> ::= <letter> | <digit> | "-" | "_"
 
-// Quoted strings may not span lines.
-//
-// SPEC DIVERGENCE: ZRFC 15 strings are UTF-8 and quote characters include the
-// Unicode neutral/forward/backward variants (U+2018/U+2019, U+201C/U+201D,
-// etc.), with backslash escapes defined only for quotes and backslash. The
-// compiler accepts only ASCII ' ` " as quotes (curly quotes are illegal
-// characters), rejects non-ASCII in unquoted words, treats backtick as a
-// single-quote flavor (not in the spec), and lets backslash escape any char.
+// Quoted strings may not span lines. Strings are UTF-8, and the
+// quote characters include the Unicode neutral/forward/backward variants 
 <quoted-string> ::= <single-quoted-string> | <double-quoted-string>
 
 <single-quoted-string> ::= <single-quote> <single-quote-chars> <single-quote>
 
-<double-quoted-string> ::= '"' <double-quote-chars> '"'
+<double-quoted-string> ::= <double-quote> <double-quote-chars> <double-quote>
 
 <single-quote-chars> ::= (<any-char-except-single-quote-or-backslash> | <escaped-char>)*
 
 <double-quote-chars> ::= (<any-char-except-double-quote-or-backslash> | <escaped-char>)*
 
-// Backslash escapes ANY following character, not just quotes ("\x" == "x").
-<escaped-char> ::= "\" <any-char>
+// Backslash escapes are defined ONLY for quote characters (any variant) and
+// backslash itself; a backslash before any other character in a quoted string
+// is an error. Outside quotes, backslash is not an escape (it is rejected like
+// any other illegal unquoted character).
+<escaped-char> ::= "\" (<single-quote> | <double-quote> | "\")
 
 // A set may be empty ("clearance:{}" is accepted and is equivalent to the
 // bare key-presence "clearance:"). Sets do NOT nest. A quoted set value may
@@ -211,12 +209,15 @@
 
 <set-value> ::= <unquoted-value> | <quoted-string>
 
-// A quoted string opened with one single-quote flavor may be closed by the
-// other ("'foo`" is valid).
-<single-quote> ::= "'" | "`"
+// A quoted string opened with one flavor from a family may be closed by any
+// other flavor of the same family ("'foo`" and "“foo\"" are valid), but the
+// families do not mix ("'foo\"" is unterminated).
+<single-quote> ::= "'" | "`" | "´" | "‘" | "’"     
 
-<letter> ::= "a".."z" | "A".."Z"
+<double-quote> ::= '"' | '“' | '”'                
 
-<digit> ::= "0".."9"
+<letter> ::= any Unicode alphabetic character (Rust char::is_alphabetic)
+
+<digit> ::= any Unicode numeric character (Rust char::is_numeric)
 
 <comment> ::= "#" <any-chars-to-eol> | "//" <any-chars-to-eol>

--- a/zpl.bnf
+++ b/zpl.bnf
@@ -145,7 +145,7 @@
 // is matched verbatim), and a quoted segment cannot take a prefix or suffix.
 <unquoted-name> ::= <name-char>+
 
-<name-char> ::= <letter> | <digit> | "-" | "_" | "."
+<name-char> ::= <identifier-char> | "-" | "_" | "."
 
 <class-name> ::= <built-in-class-name> | <name>
 
@@ -180,7 +180,7 @@
 
 <decimal-number> ::= <digit>+ "." <digit>+
 
-<value-char> ::= <letter> | <digit> | "-" | "_"
+<value-char> ::= <identifier-char> | "-" | "_"
 
 // Quoted strings may not span lines. Strings are UTF-8, and the
 // quote characters include the Unicode neutral/forward/backward variants 
@@ -214,9 +214,10 @@
 
 <double-quote> ::= '"' | '“' | '”'                
 
-// In code: Rust's char::is_alphabetic and char::is_numeric.
-<letter> ::= ? Unicode Alphabetic ?
+// Decimal numbers use ASCII digits only. Unicode digits in an identifier 
+// are just opaque characters ("level:٣" is an ordinary value word, not a number).
+<identifier-char> ::= ? Unicode alphanumeric ?
 
-<digit> ::= ? Unicode Number ?
+<digit> ::= "0".."9"
 
 <comment> ::= "#" <any-chars-to-eol> | "//" <any-chars-to-eol>


### PR DESCRIPTION
Updated compiler functionality for UTF8 strings. Backward, neutral, and forward single and double quotation marks are now supported and can be opened and closed by any format (backward + forward) as long as they both single or double quotation marks. Expanded to not just accept ASCII characters. Backward slashes are treated as a normal char outside of quote but within can only be used before a quotation mark or before a backwards slash to skip to the next char (ex: \ + ' or \\+ \\). 