### PR TITLE
Mk/111 ep2device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,8 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.19.2"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.19.2#2a4c9857ab8772fb4328bf9e9d94c0c99e6e9ad5"
+version = "0.20.0"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ ring = "0.17.8"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.8"
 toml = "0.9.7"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.19.2", features = ["policy"] }
+# zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.19.2", features = ["policy"] }
+zpr = { path = "../zpr-common", features = ["policy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zplc"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]
@@ -18,5 +18,4 @@ ring = "0.17.8"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.8"
 toml = "0.9.7"
-# zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.19.2", features = ["policy"] }
-zpr = { path = "../zpr-common", features = ["policy"] }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.20.0", features = ["policy"] }

--- a/README_ZPLC.md
+++ b/README_ZPLC.md
@@ -26,7 +26,7 @@ zpr_address = "fd5a..."
 ```
 * `provider` - The set of attributes required in order to provide the node "service". These
 attributes cannot come from an external service they must be "built in".  Typically the
-only attribute you can use here is `endpoint.zpr.adapter.cn` which is the `CN` value from
+only attribute you can use here is `device.zpr.adapter.cn` which is the `CN` value from
 the nodes Noise certificate.
 * `zpr_address` - IPv6 ZPRnet address for the node. Node must be preconfigured with this
 same address.
@@ -86,7 +86,7 @@ Syntax:
 ```
 
 The **TSNAME** of `default` is special and is used to check the adapter CN values.
-It is responsible for the property: `endpoint.zpr.adapter.cn`.  The default
+It is responsible for the property: `device.zpr.adapter.cn`.  The default
 service requires a `cert_path` which should be set to the certificate of the
 authority which has signed the NOISE certs given to the adapters.
 
@@ -153,11 +153,11 @@ port = 1234
 An attribute is of the form: `<NAMESPACE>.<ATTR_KEY>`.  There may be additional periods
 in the `<ATTR_KEY>` value.
 
-Every attribute must be in one of the ZPR namespaces: "endpoint", "user", or "service".
+Every attribute must be in one of the ZPR namespaces: "device", "user", or "service".
 
 Valid attribute examples:
 * `user.id`
-* `endpoint.tmp.key_hash`
+* `device.tmp.key_hash`
 * `service.type`
 
 Attributes from services may be single value, multi value, or tags.  An attribute list
@@ -166,14 +166,14 @@ the attribute is set as:
 
 * **Single Value** - Just a plain string, eg `"user.clearance"`.
 * **Multi Value** - Add a '{}' to the end, eg `"user.role{}"`.
-* **Tag** - Prefixed with a hash mark (`#`), eg `"#endpoint.secure`.
+* **Tag** - Prefixed with a hash mark (`#`), eg `"#device.secure`.
 
 When specifying the `returns_attributes` use a map format with an arrow '->':
 
 
 ```toml
 returns_attributes = [
-  "tint -> endpoint.tint",
+  "tint -> device.tint",
   "color -> user.color",
   "govt -> #user.government",
   "bas_id -> user.id",
@@ -268,7 +268,7 @@ come from the ZPL, but you can also put them in the configuration.  Eg,
 [service.WebService]
 protocol = "http"
 port = 80
-provider = [[ "endpoint.zpr.adapter.cn", "foo.blah"]]
+provider = [[ "device.zpr.adapter.cn", "foo.blah"]]
 ```
 
 If you need a static address for a service, the service adapter needs to specify
@@ -279,7 +279,7 @@ with a `zpr.addr` attribute.  For example,
 [service.WebService]
 protocol = "http"
 port = 80
-provider = [[ "endpoint.zpr.adapter.cn", "foo.blah"], ["zpr.addr", "fd5a:5052:2020::19"]]
+provider = [[ "device.zpr.adapter.cn", "foo.blah"], ["zpr.addr", "fd5a:5052:2020::19"]]
 ```
 
 

--- a/src/allow.rs
+++ b/src/allow.rs
@@ -13,7 +13,7 @@ use zpr::policy_types::{AttrDomain, Attribute};
 #[derive(Debug, Default)]
 struct ParseAllowState {
     root_tok: Token,
-    client_endpoint_clause: Option<Clause>,
+    client_device_clause: Option<Clause>,
     client_user_clause: Option<Clause>,
     client_service_clause: Option<Clause>,
     service_clause: Option<Clause>,
@@ -30,18 +30,18 @@ impl ParseAllowState {
 
     /// True when we have none of the client clauses set.
     fn client_clauses_is_none(&self) -> bool {
-        self.client_endpoint_clause.is_none()
+        self.client_device_clause.is_none()
             && self.client_user_clause.is_none()
             && self.client_service_clause.is_none()
     }
 
     /// This consumes all the clauses or panics.
     ///
-    /// Note that every allow clause will get a user and endpoint clause in the client vector
+    /// Note that every allow clause will get a user and device clause in the client vector
     /// even if they are just the default.
     ///
     /// The `server` vector in the [AllowClause] will just have one element -- a service clause
-    /// that may have attributes from other domains (eg, endpoint or user attributes).
+    /// that may have attributes from other domains (eg, device or user attributes).
     fn to_allow_clause(&mut self, clause_id: usize, last_tok: Token) -> AllowClause {
         let mut client_user_clause = self.client_user_clause.take().unwrap_or(Clause::new(
             ClassFlavor::User,
@@ -49,18 +49,18 @@ impl ParseAllowState {
             self.root_tok.clone(),
         ));
 
-        let mut client_endpoint_clause = self.client_endpoint_clause.take().unwrap_or(Clause::new(
-            ClassFlavor::Endpoint,
-            zpl::DEF_CLASS_ENDPOINT_NAME,
+        let mut client_device_clause = self.client_device_clause.take().unwrap_or(Clause::new(
+            ClassFlavor::Device,
+            zpl::DEF_CLASS_DEVICE_NAME,
             self.root_tok.clone(),
         ));
 
         // For now keep service as none if it is not yet defined.
         let mut opt_client_service_clause = self.client_service_clause.take();
 
-        // Move any non endpoint attributes from the endpoint clause into the correct one.
+        // Move any non device attributes from the device clause into the correct one.
         let mut keep_attrs = Vec::new();
-        for attr in client_endpoint_clause.with {
+        for attr in client_device_clause.with {
             match attr.get_domain_ref() {
                 &AttrDomain::Service => {
                     if let Some(ref mut sc) = opt_client_service_clause {
@@ -79,7 +79,7 @@ impl ParseAllowState {
                 _ => keep_attrs.push(attr),
             }
         }
-        client_endpoint_clause.with = keep_attrs;
+        client_device_clause.with = keep_attrs;
 
         // Move any non user attributes from the user clause into the correct one.
         let mut keep_attrs = Vec::new();
@@ -98,7 +98,7 @@ impl ParseAllowState {
                         opt_client_service_clause = Some(cl)
                     }
                 }
-                &AttrDomain::Endpoint => client_endpoint_clause.with.push(attr),
+                &AttrDomain::Device => client_device_clause.with.push(attr),
                 _ => keep_attrs.push(attr),
             }
         }
@@ -106,7 +106,7 @@ impl ParseAllowState {
 
         let mut client_clauses = Vec::new();
         client_clauses.push(client_user_clause);
-        client_clauses.push(client_endpoint_clause);
+        client_clauses.push(client_device_clause);
         if let Some(sc) = opt_client_service_clause.take() {
             client_clauses.push(sc);
         }
@@ -130,14 +130,14 @@ impl ParseAllowState {
 ///
 /// Format of the allow statement is:
 ///
-/// allow (<user-clause>|<service-clause>) on <endpoint-clause> to access <service-clause>
+/// allow (<user-clause>|<service-clause>) on <device-clause> to access <service-clause>
 ///
-/// If there are both endpoint and user/service clauses they are separated by 'on'.
-/// You can omit either user or endpoint clauses:
+/// If there are both device and user/service clauses they are separated by 'on'.
+/// You can omit either user or device clauses:
 ///
 /// allow <user-clause> to access <service-clause>
 /// allow <service-clause> to access <service-clause>
-/// allow <endpoint-clause> to access <service-clause>
+/// allow <device-clause> to access <service-clause>
 ///
 /// `classes_idx` maps class names and AKA names to their canonical names (eg, "services" -> "service").
 /// `classs_map` maps class canonical name to [Class] struct.
@@ -171,7 +171,7 @@ pub fn parse_allow(
         Some(tok) => {
             let cn = ps.class_name.as_ref().unwrap();
 
-            // If we hit a TO then we expect one to have parsed an endpoint, user or even service clause.
+            // If we hit a TO then we expect one to have parsed an device, user or even service clause.
             // The LHS can only name one class.  There may be other attributes in different classes
             // applied.  Eg, 'service.blue, orange users'.
             match tok.tt {
@@ -182,9 +182,9 @@ pub fn parse_allow(
                             let uc = ps.to_clause(ClassFlavor::User)?;
                             parse_state.client_user_clause = Some(uc);
                         }
-                        ClassFlavor::Endpoint => {
-                            let dc = ps.to_clause(ClassFlavor::Endpoint)?;
-                            parse_state.client_endpoint_clause = Some(dc);
+                        ClassFlavor::Device => {
+                            let dc = ps.to_clause(ClassFlavor::Device)?;
+                            parse_state.client_device_clause = Some(dc);
                         }
                         ClassFlavor::Service => {
                             let dc = ps.to_clause(ClassFlavor::Service)?;
@@ -202,7 +202,7 @@ pub fn parse_allow(
 
                 // If we hit an ON then we expect to have parsed a user or service clause.
                 TokenType::On => {
-                    // Hit ON which means we must have parsed a user clause, and we expect an endpoint clause to follow.
+                    // Hit ON which means we must have parsed a user clause, and we expect an device clause to follow.
                     match classes_map.get(cn).unwrap().flavor {
                         ClassFlavor::User => {
                             let dc = ps.to_clause(ClassFlavor::User)?;
@@ -243,7 +243,7 @@ pub fn parse_allow(
     }
 
     // If we get this far, we have parsed up to a ON or a TO.
-    // If it's a ON then we expect an endpoint clause next.
+    // If it's a ON then we expect an device clause next.
     // If it's a TO then we expect a RHS service clause next.
     let tok = tokens.next().unwrap();
     match tok.tt {
@@ -251,15 +251,15 @@ pub fn parse_allow(
             if parse_state.client_clauses_is_none() {
                 panic!("assertion fails - no client clauses on LHS");
             }
-            if parse_state.client_endpoint_clause.is_some() {
+            if parse_state.client_device_clause.is_some() {
                 return Err(CompilationError::AllowStmtParseError(
-                    format!("endpoint clause on RHS preceeds ON"),
+                    format!("device clause on RHS preceeds ON"),
                     parse_state.root_tok.line,
                     parse_state.root_tok.col,
                 ));
             }
-            // Ok, now parse an ENDPOINT clause, returns having found but not parsed 'TO'.
-            if !try_parse_allow_endpoint_clause(
+            // Ok, now parse an DEVICE clause, returns having found but not parsed 'TO'.
+            if !try_parse_allow_device_clause(
                 &mut parse_state,
                 &mut tokens,
                 classes_idx,
@@ -267,7 +267,7 @@ pub fn parse_allow(
             )? {
                 // Hmm, a non error failure?
                 return Err(CompilationError::AllowStmtParseError(
-                    "expected an endpoint clause to follow ON".to_string(),
+                    "expected an device clause to follow ON".to_string(),
                     tok.line,
                     tok.col,
                 ));
@@ -358,14 +358,14 @@ fn check_clause_composition(
     for clause in clauses {
         match clause.flavor {
             ClassFlavor::User => usr_ep_svc.0 += 1,
-            ClassFlavor::Endpoint => usr_ep_svc.1 += 1,
+            ClassFlavor::Device => usr_ep_svc.1 += 1,
             ClassFlavor::Service => usr_ep_svc.2 += 1,
             _ => (),
         }
     }
     if let Some(err_msg) = match usr_ep_svc {
         (a, _, _) if a > 1 => Some(format!("too many user clauses {explain}")),
-        (_, b, _) if b > 1 => Some(format!("too may endpoint clauses {explain}")),
+        (_, b, _) if b > 1 => Some(format!("too may device clauses {explain}")),
         (_, _, c) if c > 1 => Some(format!("too many service clauses {explain}")),
         _ => None,
     } {
@@ -378,9 +378,9 @@ fn check_clause_composition(
     Ok(())
 }
 
-/// Parse from <endpoint-clause> up to the 'TO' (of 'TO ACCESS')
-/// If this succeeds, it sets the endpoint clause in the [ParseAllowState].
-fn try_parse_allow_endpoint_clause<'a, I>(
+/// Parse from <device-clause> up to the 'TO' (of 'TO ACCESS')
+/// If this succeeds, it sets the device clause in the [ParseAllowState].
+fn try_parse_allow_device_clause<'a, I>(
     pa_state: &mut ParseAllowState,
     tokens: &mut Peekable<I>,
     classes_idx: &HashMap<String, String>,
@@ -395,17 +395,17 @@ where
         tokens,
         classes_idx,
         &ParseOpts::stop_at(TokenType::To),
-        "endpoint clause",
+        "device clause",
     )?;
 
-    // This is a good parse if we actually got a endpoint flavor class.
+    // This is a good parse if we actually got a device flavor class.
     let cn = ps.class_name.as_ref().unwrap();
-    if classes_map.get(cn).unwrap().flavor == ClassFlavor::Endpoint {
-        let ec = ps.to_clause(ClassFlavor::Endpoint)?;
-        pa_state.client_endpoint_clause = Some(ec);
+    if classes_map.get(cn).unwrap().flavor == ClassFlavor::Device {
+        let ec = ps.to_clause(ClassFlavor::Device)?;
+        pa_state.client_device_clause = Some(ec);
         Ok(true)
     } else {
-        Ok(false) // not an endpoint clause
+        Ok(false) // not an device clause
     }
 }
 
@@ -413,7 +413,7 @@ where
 /// The passed tokens MUST start with "ACCESS". There may be a "SIGNAL"
 /// token after the "ACCESS" tokens
 ///
-/// The service clause may have a trailing ON <endpoint-clause>.
+/// The service clause may have a trailing ON <device-clause>.
 /// There may also be a signal clause after the service clause. If there is a
 /// signal clause, tokens will remain in the queue after this function, otherwise
 /// this function will process all the tokens.
@@ -471,41 +471,41 @@ where
                     tokens,
                     classes_idx,
                     &ParseOpts::stop_at_any(&[TokenType::Eos, TokenType::Signal]),
-                    "service endpoint clause",
+                    "service device clause",
                 )?;
 
-                // This is a good parse if we actually got a endpoint or signal flavor class.
+                // This is a good parse if we actually got a device or signal flavor class.
                 let cn = nested_ps.class_name.as_ref().unwrap();
-                if classes_map.get(cn).unwrap().flavor == ClassFlavor::Endpoint {
-                    let service_ec = nested_ps.to_clause(ClassFlavor::Endpoint)?;
+                if classes_map.get(cn).unwrap().flavor == ClassFlavor::Device {
+                    let service_ec = nested_ps.to_clause(ClassFlavor::Device)?;
 
                     // Since ZPL could use a defined class in the on clause we need to walk the tree and
                     // gather any attributes.
-                    let mut all_endpoint_attrs =
+                    let mut all_device_attrs =
                         collect_all_attributes(&service_ec.class, classes_map);
-                    all_endpoint_attrs.extend(service_ec.with);
+                    all_device_attrs.extend(service_ec.with);
 
-                    for ec_attr in &all_endpoint_attrs {
+                    for ec_attr in &all_device_attrs {
                         let mut domained_attr = ec_attr.clone();
                         if domained_attr.is_unspecified_domain() {
-                            domained_attr.set_domain(AttrDomain::Endpoint);
-                        } else if !domained_attr.is_domain(AttrDomain::Endpoint) {
-                            // This is not permitted. You can only talk about endpoints in the ON clause.
+                            domained_attr.set_domain(AttrDomain::Device);
+                        } else if !domained_attr.is_domain(AttrDomain::Device) {
+                            // This is not permitted. You can only talk about devices in the ON clause.
                             return Err(CompilationError::AllowStmtParseError(
                                 format!(
-                                    "illegal non-endpoint attribute in service ON clause: '{}'",
+                                    "illegal non-device attribute in service ON clause: '{}'",
                                     domained_attr.to_instance_string()
                                 ),
                                 pa_state.root_tok.line,
                                 pa_state.root_tok.col,
                             ));
                         }
-                        service_clause.with.push(domained_attr); // TODO: Are these already in endpoint domain?
+                        service_clause.with.push(domained_attr); // TODO: Are these already in device domain?
                     }
                 } else {
                     return Err(CompilationError::AllowStmtParseError(
                         format!(
-                            "expected an endpoint class in service ON clause, got: '{}'",
+                            "expected an device class in service ON clause, got: '{}'",
                             cn
                         ),
                         pa_state.root_tok.line,
@@ -865,13 +865,13 @@ mod test {
     #[test]
     fn test_parses_valid_on_clause() {
         let valids = vec![
-            "allow blue users to access services on level:seven endpoints",
-            "allow blue users to access services on orange endpoints",
-            "allow blue users to access services on orange, level:seven endpoints",
-            "allow blue users on green endpoints to access services",
+            "allow blue users to access services on level:seven devices",
+            "allow blue users to access services on orange devices",
+            "allow blue users to access services on orange, level:seven devices",
+            "allow blue users on green devices to access services",
             "allow blue users to access services and signal \"blue\" to service",
-            "allow blue users on green endpoints to access services and signal \"blue\" to service",
-            "allow blue users to access services on level:seven endpoints and signal \"blue\" to service",
+            "allow blue users on green devices to access services and signal \"blue\" to service",
+            "allow blue users to access services on level:seven devices and signal \"blue\" to service",
         ];
 
         let mut classes: HashMap<String, Class> = HashMap::new();
@@ -908,7 +908,7 @@ mod test {
     fn test_fails_on_invalid_on_clause() {
         let invalids = vec![
             "allow blue users to access services on",
-            "allow blue users to access services on level:seven on endpoints",
+            "allow blue users to access services on level:seven on devices",
             "allow on blue users to access services",
             "allow blue users to access services on orange",
             "allow blue users to signal to services",
@@ -947,7 +947,7 @@ mod test {
 
     #[test]
     fn test_sets_attrs_correctly_trailing_on() {
-        let statement = "allow blue users to access services on level:seven endpoints";
+        let statement = "allow blue users to access services on level:seven devices";
 
         let mut classes: HashMap<String, Class> = HashMap::new();
         for defclass in Class::defaults() {
@@ -967,7 +967,7 @@ mod test {
 
         // Blue tag goes on user.
 
-        assert_eq!(2, clause.client.len(), "{:?}", clause.client); // user & endpoint
+        assert_eq!(2, clause.client.len(), "{:?}", clause.client); // user & device
         let mut matched = false;
         for lhs_clause in &clause.client {
             if lhs_clause.flavor == ClassFlavor::User {
@@ -982,7 +982,7 @@ mod test {
         assert!(matched, "failed to find a user clause");
         matched = false;
 
-        // level:seven attr goes in as an endpoint domain attribute on the service.
+        // level:seven attr goes in as an device domain attribute on the service.
         assert_eq!(1, clause.server.len(), "{:?}", clause.server); // service only
         for rhs_clause in &clause.server {
             if rhs_clause.flavor == ClassFlavor::Service {
@@ -990,16 +990,16 @@ mod test {
                 rhs_clause
                     .with
                     .iter()
-                    .find(|a| a.to_instance_string() == "endpoint.level:seven")
+                    .find(|a| a.to_instance_string() == "device.level:seven")
                     .expect("level:seven tag missing from service clause");
             }
         }
-        assert!(matched, "failed to find endpoint class in RHS");
+        assert!(matched, "failed to find device class in RHS");
     }
 
     #[test]
     fn test_sets_attrs_correctly_user_on() {
-        let statement = "allow blue users on level:seven endpoints to access services";
+        let statement = "allow blue users on level:seven devices to access services";
 
         let mut classes: HashMap<String, Class> = HashMap::new();
         for defclass in Class::defaults() {
@@ -1017,9 +1017,9 @@ mod test {
         let tokens = tz.tokens;
         let clause = parse_allow(&tokens, 1, &class_index, &classes).unwrap();
 
-        assert_eq!(2, clause.client.len()); // users, endpoints
+        assert_eq!(2, clause.client.len()); // users, devices
         let mut matched_user = false;
-        let mut matched_endpoint = false;
+        let mut matched_device = false;
         for lhs_clause in clause.client {
             // Blue tag goes on user.
             if lhs_clause.flavor == ClassFlavor::User {
@@ -1029,24 +1029,24 @@ mod test {
                     .iter()
                     .find(|a| a.to_instance_string() == "#user.blue")
                     .expect("blue tag missing from user clause");
-            } else if lhs_clause.flavor == ClassFlavor::Endpoint {
-                // level:seven attr goes in as an endpoint attribute
-                matched_endpoint = true;
+            } else if lhs_clause.flavor == ClassFlavor::Device {
+                // level:seven attr goes in as an device attribute
+                matched_device = true;
                 lhs_clause
                     .with
                     .iter()
-                    .find(|a| a.to_instance_string() == "endpoint.level:seven")
-                    .expect("level:seven tag missing from endpoint clause");
+                    .find(|a| a.to_instance_string() == "device.level:seven")
+                    .expect("level:seven tag missing from device clause");
             }
         }
         assert!(matched_user, "failed to locate user clause in LHS");
-        assert!(matched_endpoint, "failed to locate endpoint clause in LHS");
+        assert!(matched_device, "failed to locate device clause in LHS");
     }
 
     #[test]
     fn test_sets_attrs_correctly_two_on() {
         let statement =
-            "allow blue users on level:seven endpoints to access services on level:eight endpoints";
+            "allow blue users on level:seven devices to access services on level:eight devices";
 
         let mut classes: HashMap<String, Class> = HashMap::new();
         for defclass in Class::defaults() {
@@ -1064,11 +1064,11 @@ mod test {
         let tokens = tz.tokens;
         let clause = parse_allow(&tokens, 1, &class_index, &classes).unwrap();
 
-        assert_eq!(2, clause.client.len()); // users, endpoints
+        assert_eq!(2, clause.client.len()); // users, devices
         assert_eq!(1, clause.server.len()); // services
 
         let mut matched_user = false;
-        let mut matched_endpoint = false;
+        let mut matched_device = false;
         let mut matched_service = false;
 
         for lhs_clause in clause.client {
@@ -1082,20 +1082,20 @@ mod test {
                         .find(|a| a.to_instance_string() == "#user.blue")
                         .expect("blue tag missing from user clause");
                 }
-                ClassFlavor::Endpoint => {
-                    // level:seven attr goes in as an endpoint attribute
-                    matched_endpoint = true;
+                ClassFlavor::Device => {
+                    // level:seven attr goes in as an device attribute
+                    matched_device = true;
                     lhs_clause
                         .with
                         .iter()
-                        .find(|a| a.to_instance_string() == "endpoint.level:seven")
-                        .expect("level:seven tag missing from endpoint clause");
+                        .find(|a| a.to_instance_string() == "device.level:seven")
+                        .expect("level:seven tag missing from device clause");
                 }
                 _ => (),
             }
         }
         assert!(matched_user, "failed to locate user clause in LHS");
-        assert!(matched_endpoint, "failed to locate endpoint clause in LHS");
+        assert!(matched_device, "failed to locate device clause in LHS");
 
         for rhs_clause in clause.server {
             match rhs_clause.flavor {
@@ -1104,7 +1104,7 @@ mod test {
                     rhs_clause
                         .with
                         .iter()
-                        .find(|a| a.to_instance_string() == "endpoint.level:eight")
+                        .find(|a| a.to_instance_string() == "device.level:eight")
                         .expect("level:eight tag missing from service clause");
                 }
                 _ => (),
@@ -1115,7 +1115,8 @@ mod test {
 
     #[test]
     fn test_sets_service_attrs_lhs() {
-        let statement = "allow blue services on level:seven endpoints to access services on level:eight endpoints";
+        let statement =
+            "allow blue services on level:seven devices to access services on level:eight devices";
 
         let mut classes: HashMap<String, Class> = HashMap::new();
         for defclass in Class::defaults() {
@@ -1133,11 +1134,11 @@ mod test {
         let tokens = tz.tokens;
         let clause = parse_allow(&tokens, 1, &class_index, &classes).unwrap();
 
-        assert_eq!(3, clause.client.len()); // services, users, endpoints
+        assert_eq!(3, clause.client.len()); // services, users, devices
         assert_eq!(1, clause.server.len()); // services
 
         let mut matched_user = false;
-        let mut matched_endpoint = false;
+        let mut matched_device = false;
         let mut matched_service = false;
 
         for lhs_clause in clause.client {
@@ -1160,20 +1161,20 @@ mod test {
                                 .as_str(),
                         );
                 }
-                ClassFlavor::Endpoint => {
-                    // level:seven attr goes in as an endpoint attribute
-                    matched_endpoint = true;
+                ClassFlavor::Device => {
+                    // level:seven attr goes in as an device attribute
+                    matched_device = true;
                     lhs_clause
                         .with
                         .iter()
-                        .find(|a| a.to_instance_string() == "endpoint.level:seven")
-                        .expect("level:seven tag missing from endpoint clause");
+                        .find(|a| a.to_instance_string() == "device.level:seven")
+                        .expect("level:seven tag missing from device clause");
                 }
                 _ => (),
             }
         }
         assert!(matched_user, "failed to locate user clause in LHS");
-        assert!(matched_endpoint, "failed to locate endpoint clause in LHS");
+        assert!(matched_device, "failed to locate device clause in LHS");
         assert!(matched_service, "failed to locate service clause in LHS");
 
         for rhs_clause in clause.server {
@@ -1183,7 +1184,7 @@ mod test {
                     rhs_clause
                         .with
                         .iter()
-                        .find(|a| a.to_instance_string() == "endpoint.level:eight")
+                        .find(|a| a.to_instance_string() == "device.level:eight")
                         .expect("level:eight tag missing from service clause");
                 }
                 _ => (),
@@ -1194,7 +1195,7 @@ mod test {
 
     #[test]
     fn test_multi_value_attrs() {
-        let statement = "allow colors:{blue, red} users on levels:{1, 2} endpoints to access services on levels:{9, 10} endpoints";
+        let statement = "allow colors:{blue, red} users on levels:{1, 2} devices to access services on levels:{9, 10} devices";
 
         let mut classes: HashMap<String, Class> = HashMap::new();
         for defclass in Class::defaults() {
@@ -1212,11 +1213,11 @@ mod test {
         let tokens = tz.tokens;
         let clause = parse_allow(&tokens, 1, &class_index, &classes).unwrap();
 
-        assert_eq!(2, clause.client.len()); // users, endpoints
+        assert_eq!(2, clause.client.len()); // users, devices
         assert_eq!(1, clause.server.len()); // services
 
         let mut matched_user = false;
-        let mut matched_endpoint = false;
+        let mut matched_device = false;
         let mut matched_service = false;
 
         for lhs_clause in clause.client {
@@ -1229,19 +1230,19 @@ mod test {
                         .find(|a| a.to_instance_string() == "user.colors:{blue, red}")
                         .expect("colors{blue,red} missing from user clause");
                 }
-                ClassFlavor::Endpoint => {
-                    matched_endpoint = true;
+                ClassFlavor::Device => {
+                    matched_device = true;
                     lhs_clause
                         .with
                         .iter()
-                        .find(|a| a.to_instance_string() == "endpoint.levels:{1, 2}")
-                        .expect("levels{1,2} missing from endpoint clause");
+                        .find(|a| a.to_instance_string() == "device.levels:{1, 2}")
+                        .expect("levels{1,2} missing from device clause");
                 }
                 _ => (),
             }
         }
         assert!(matched_user, "failed to locate user clause in LHS");
-        assert!(matched_endpoint, "failed to locate endpoint clause in LHS");
+        assert!(matched_device, "failed to locate device clause in LHS");
 
         for rhs_clause in clause.server {
             match rhs_clause.flavor {
@@ -1250,7 +1251,7 @@ mod test {
                     rhs_clause
                         .with
                         .iter()
-                        .find(|a| a.to_instance_string() == "endpoint.levels:{9, 10}")
+                        .find(|a| a.to_instance_string() == "device.levels:{9, 10}")
                         .expect("levels{9,10} missing from service clause");
                 }
                 _ => (),
@@ -1353,18 +1354,18 @@ mod test {
         }
     }
 
-    // Using a non-endpoint class (e.g. "users") in the ON clause on the RHS of
-    // an allow statement (after the service) must fail because only endpoint
+    // Using a non-device class (e.g. "users") in the ON clause on the RHS of
+    // an allow statement (after the service) must fail because only device
     // classes are valid there.
     #[test]
-    fn test_service_on_non_endpoint_class() {
+    fn test_service_on_non_device_class() {
         let statement = "allow blue users to access services on users";
         let (class_index, classes) = default_classes();
         let cctx = CompilationCtx::default();
         let tz = tokenize_str(statement, &cctx).unwrap();
         match parse_allow(&tz.tokens, 1, &class_index, &classes) {
-            Ok(c) => panic!("should have failed: ON clause class is not an endpoint: {c:?}"),
-            Err(e) => assert!(e.to_string().contains("endpoint"), "unexpected error: {e}"),
+            Ok(c) => panic!("should have failed: ON clause class is not an device: {c:?}"),
+            Err(e) => assert!(e.to_string().contains("device"), "unexpected error: {e}"),
         }
     }
 }

--- a/src/compilation.rs
+++ b/src/compilation.rs
@@ -495,7 +495,7 @@ mod test {
     zpr_address = "fd5a:5052:90de::1"
     interfaces = [ "in1" ]
     in1.netaddr = "127.0.0.1:5000"
-    provider = [["endpoint.zpr.adapter.cn", "fee"]]
+    provider = [["device.zpr.adapter.cn", "fee"]]
 
     [visa_service]
     dock_node = "n0"
@@ -518,7 +518,7 @@ mod test {
     zpr_address = "fd5a:5052:90de::1"
     interfaces = [ "in1" ]
     in1.netaddr = "127.0.0.1:5000"
-    provider = [["endpoint.zpr.adapter.cn", "fee"]]
+    provider = [["device.zpr.adapter.cn", "fee"]]
 
     [visa_service]
     dock_node = "n0"
@@ -532,7 +532,7 @@ mod test {
     cert_path = ""
     returns_attributes = [ "color -> user.color", "content -> service.content", "bas_id -> user.bas_id" ]
     identity_attributes = [ "bas_id" ]
-    provider = [[ "endpoint.zpr.adapter.cn", "bas.zpr.org" ]]
+    provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
 
 
     [protocols.http]
@@ -552,8 +552,8 @@ mod test {
     #[test]
     fn simple_compile() {
         let zpl = r#"
-        define Webby as service with endpoint.zpr.adapter.cn.
-        allow zpr.adapter.cn: endpoints to access Webby.
+        define Webby as service with device.zpr.adapter.cn.
+        allow zpr.adapter.cn: devices to access Webby.
         "#;
 
         let tempdir = TempDir::new("simple_compile");
@@ -581,7 +581,7 @@ mod test {
     fn define_requires_with() {
         let zpl = r#"
         define Webby as service.
-        allow zpr.adapter.cn: endpoints to access Webby.
+        allow zpr.adapter.cn: devices to access Webby.
         "#;
 
         let tempdir = TempDir::new("define_requires_with");
@@ -615,7 +615,7 @@ mod test {
         zpr_address = "fd5a:5052:90de::1"
         interfaces = [ "in1" ]
         in1.netaddr = "127.0.0.1:5000"
-        provider = [["endpoint.zpr.adapter.cn", "fee"]]
+        provider = [["device.zpr.adapter.cn", "fee"]]
 
         [visa_service]
         dock_node = "n0"
@@ -629,12 +629,12 @@ mod test {
 
         [services.Webby]
         protocol = "http"
-        provider = [["endpoint.zpr.adapter.cn", ""]]
+        provider = [["device.zpr.adapter.cn", ""]]
         "#;
 
         let zpl = r#"
         define Webby as service.
-        allow zpr.adapter.cn: endpoints to access Webby.
+        allow zpr.adapter.cn: devices to access Webby.
         "#;
 
         let tempdir = TempDir::new("define_ok_without_with");
@@ -660,8 +660,8 @@ mod test {
     #[test]
     fn cannot_use_cn_as_tag() {
         let zpl = r#"
-        define Webby as service with endpoint.zpr.adapter.cn.
-        allow zpr.adapter.cn endpoints to access Webby.
+        define Webby as service with device.zpr.adapter.cn.
+        allow zpr.adapter.cn devices to access Webby.
         "#;
 
         let tempdir = TempDir::new("cannot_use_cn_as_tag");
@@ -690,7 +690,7 @@ mod test {
     fn test_svc_attrs_must_be_defined() {
         let zpl = r#"
         define Webby as service with unknown_attr.
-        allow cn: endpoints to access services.
+        allow cn: devices to access services.
         "#;
 
         let tempdir = TempDir::new("test_svc_attrs_must_be_defined");
@@ -718,8 +718,8 @@ mod test {
     #[test]
     fn test_allow_attrs_must_be_defined() {
         let zpl = r#"
-        define Webby as service with endpoint.zpr.adapter.cn.
-        allow unknown_attr: endpoints to access services.
+        define Webby as service with device.zpr.adapter.cn.
+        allow unknown_attr: devices to access services.
         "#;
 
         let tempdir = TempDir::new("test_allow_attrs_must_be_defined");
@@ -738,7 +738,7 @@ mod test {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("endpoint.unknown_attr: not found"),
+            err_msg.contains("device.unknown_attr: not found"),
             "unexpected error message: {}",
             err_msg
         );

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1062,10 +1062,10 @@ mod test {
         assert_eq!(ts.returns_attrs.len(), 1);
         assert_eq!(
             ts.returns_attrs[zpl::KATTR_CN].zpl_key(),
-            "endpoint.zpr.adapter.cn"
+            "device.zpr.adapter.cn"
         );
         assert_eq!(ts.identity_attrs.len(), 1);
-        assert_eq!(ts.identity_attrs[0], "endpoint.zpr.adapter.cn");
+        assert_eq!(ts.identity_attrs[0], "device.zpr.adapter.cn");
     }
 
     #[test]
@@ -1127,7 +1127,7 @@ mod test {
         api = "validation/2"
         cert_path = "foo.pem"
         prefix = "bar.hop"
-        returns_attributes = ["foo -> user.foo", "fee -> user.fee", "foo -> #endpoint.foo"]
+        returns_attributes = ["foo -> user.foo", "fee -> user.fee", "foo -> #device.foo"]
         identity_attributes = ["foo"]
         provider = [["foo", "bar"]]
         "##;

--- a/src/config/trusted_service.rs
+++ b/src/config/trusted_service.rs
@@ -231,15 +231,15 @@ mod test {
 
     #[test]
     fn test_parse_attribute_mapping_tag() {
-        let mapping = "service_key -> #endpoint.tag";
+        let mapping = "service_key -> #device.tag";
         let result = parse_attribute_mapping(mapping);
 
         assert!(result.is_ok());
         let (service_key_name, attr) = result.unwrap();
 
         assert_eq!(service_key_name, "service_key");
-        assert_eq!(*attr.get_domain_ref(), AttrDomain::Endpoint);
-        assert_eq!(attr.zpl_value(), "endpoint.tag");
+        assert_eq!(*attr.get_domain_ref(), AttrDomain::Device);
+        assert_eq!(attr.zpl_value(), "device.tag");
         assert_eq!(attr.get_values(), None);
         assert_eq!(attr.is_multi_valued(), false);
         assert_eq!(attr.is_tag(), true);

--- a/src/config_api.rs
+++ b/src/config_api.rs
@@ -889,14 +889,14 @@ mod test {
 
         [nodes.n0]
         zpr_address = "fd5a:5052:90de::1"
-        provider = [["endpoint.zpr.adapter.cn", "n0.zpr.org"]]
+        provider = [["device.zpr.adapter.cn", "n0.zpr.org"]]
 
         [nodes.n0.substrate_addrs]
         eth0 = "10.0.0.1:5000"
 
         [nodes.n1]
         zpr_address = "fd5a:5052:90de::2"
-        provider = [["endpoint.zpr.adapter.cn", "n1.zpr.org"]]
+        provider = [["device.zpr.adapter.cn", "n1.zpr.org"]]
 
         [nodes.n1.substrate_addrs]
         eth0 = "10.0.0.2:5000"
@@ -980,14 +980,14 @@ mod test {
 
         [nodes.n0]
         zpr_address = "fd5a:5052:90de::1"
-        provider = [["endpoint.zpr.adapter.cn", "n0.zpr.org"]]
+        provider = [["device.zpr.adapter.cn", "n0.zpr.org"]]
 
         [nodes.n0.substrate_addrs]
         eth0 = "10.0.0.1:5000"
 
         [nodes.n1]
         zpr_address = "fd5a:5052:90de::2"
-        provider = [["endpoint.zpr.adapter.cn", "n1.zpr.org"]]
+        provider = [["device.zpr.adapter.cn", "n1.zpr.org"]]
 
         [nodes.n1.substrate_addrs]
         eth0 = "10.0.0.2:5000"
@@ -1020,21 +1020,21 @@ mod test {
 
         [nodes.n0]
         zpr_address = "fd5a:5052:90de::1"
-        provider = [["endpoint.zpr.adapter.cn", "n0.zpr.org"]]
+        provider = [["device.zpr.adapter.cn", "n0.zpr.org"]]
 
         [nodes.n0.substrate_addrs]
         eth0 = "10.0.0.1:5000"
 
         [nodes.n1]
         zpr_address = "fd5a:5052:90de::2"
-        provider = [["endpoint.zpr.adapter.cn", "n1.zpr.org"]]
+        provider = [["device.zpr.adapter.cn", "n1.zpr.org"]]
 
         [nodes.n1.substrate_addrs]
         eth0 = "10.0.0.2:5000"
 
         [nodes.n2]
         zpr_address = "fd5a:5052:90de::3"
-        provider = [["endpoint.zpr.adapter.cn", "n2.zpr.org"]]
+        provider = [["device.zpr.adapter.cn", "n2.zpr.org"]]
 
         [nodes.n2.substrate_addrs]
         eth0 = "10.0.0.3:5000"

--- a/src/define.rs
+++ b/src/define.rs
@@ -56,7 +56,7 @@ pub fn parse_define(
     // define class_name [ aka foo ] as a parent-class-name with
     //                                    ^^^^^^^^^^^^^^^^^
     //
-    // baked in classes are: user, service, endpoint (was called device) (and their plurals)
+    // baked in classes are: user, service, device (was called device) (and their plurals)
     let mut parent_class_name =
         putil::return_literal(root_tok, tokens.next(), "parent class name", "as")?;
 
@@ -72,9 +72,9 @@ pub fn parse_define(
             parent_class_name = String::from(zpl::DEF_CLASS_SERVICE_NAME);
             ClassFlavor::Service
         }
-        zpl::DEF_CLASS_ENDPOINT_NAME | zpl::DEF_CLASS_ENDPOINT_PLURAL => {
-            parent_class_name = String::from(zpl::DEF_CLASS_ENDPOINT_NAME);
-            ClassFlavor::Endpoint
+        zpl::DEF_CLASS_DEVICE_NAME | zpl::DEF_CLASS_DEVICE_PLURAL => {
+            parent_class_name = String::from(zpl::DEF_CLASS_DEVICE_NAME);
+            ClassFlavor::Device
         }
         _ => ClassFlavor::Undefined,
     };

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -20,7 +20,7 @@ pub enum TokenType {
     AkA,
     Tag,
     Tags,
-    On, // starts an endpoint clause
+    On, // starts an device clause
     Optional,
     Multiple,
     Literal(String),
@@ -848,7 +848,7 @@ mod test {
 
     #[test]
     fn test_keyword_on() {
-        let zpl = "allow users on green endpoints to access services on red endpoints";
+        let zpl = "allow users on green devices to access services on red devices";
         let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
         let tokens = tz.tokens;
         println!("{:?}", tokens);
@@ -861,7 +861,7 @@ mod test {
 
     #[test]
     fn test_keyword_never() {
-        let zpl = "never allow users on green endpoints to access services";
+        let zpl = "never allow users on green devices to access services";
         let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
         let tokens = tz.tokens;
         println!("{:?}", tokens);
@@ -872,8 +872,7 @@ mod test {
 
     #[test]
     fn test_keyword_signal() {
-        let zpl =
-            "allow users on green endpoints to access services and signal \"sig\" to database";
+        let zpl = "allow users on green devices to access services and signal \"sig\" to database";
         let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
         let tokens = tz.tokens;
         println!("{:?}", tokens);

--- a/src/never.rs
+++ b/src/never.rs
@@ -48,7 +48,7 @@ mod test {
     use super::*;
     use crate::{context::CompilationCtx, lex::tokenize_str};
 
-    /// Build the default class registry (user, service, endpoint, VisaService)
+    /// Build the default class registry (user, service, device, VisaService)
     /// plus a corresponding name→canonical-name index that includes AKA entries.
     fn make_classes() -> (HashMap<String, String>, HashMap<String, Class>) {
         let mut classes: HashMap<String, Class> = HashMap::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -317,8 +317,8 @@ allow marketing-emps to access role:marketing services.
     #[test]
     fn test_postifx_attr_prohibited() {
         let valids = vec![
-            "allow endpoints with users with loc:italy to access services.",
-            "allow endpoints with users to access services with color:green.",
+            "allow devices with users with loc:italy to access services.",
+            "allow devices with users to access services with color:green.",
         ];
         let ctx = CompilationCtx::default();
         for valid in valids {
@@ -366,9 +366,9 @@ allow marketing-emps to access role:marketing services.
     #[test]
     fn test_omit_user() {
         let valids = vec![
-            "allow managed endpoints to access services.",
-            "allow color:red endpoints to access services.",
-            "allow managed, color:red endpoints to access services.",
+            "allow managed devices to access services.",
+            "allow color:red devices to access services.",
+            "allow managed, color:red devices to access services.",
         ];
         let ctx = CompilationCtx::default();
         for valid in valids {
@@ -388,8 +388,8 @@ allow marketing-emps to access role:marketing services.
     #[test]
     fn test_verbose_device() {
         let valids = vec![
-            "allow managed, color:red users on color:green endpoints to access green services.",
-            "allow color:red, managed users on color:green endpoints to access color:blue services.",
+            "allow managed, color:red users on color:green devices to access green services.",
+            "allow color:red, managed users on color:green devices to access color:blue services.",
         ];
         let ctx = CompilationCtx::default();
         for valid in valids {
@@ -513,7 +513,7 @@ allow marketing-emps to access role:marketing services.
 
     #[test]
     fn test_cannot_subclass_visa_service() {
-        let invalids = vec!["Define MyVs as a VisaService with endpoint.color:green."];
+        let invalids = vec!["Define MyVs as a VisaService with device.color:green."];
         let ctx = CompilationCtx::default();
         for valid in invalids {
             let tokens: Result<Tokenization, CompilationError> =
@@ -673,7 +673,7 @@ allow marketing-emps to access role:marketing services.
     // An AKA colliding with an existing name/AKA must be a Redefinition error,
     #[test]
     fn test_aka_collision_error() {
-        let input = "define bad AKA Users as endpoint.";
+        let input = "define bad AKA Users as device.";
         let ctx = CompilationCtx::default();
         let tz = tokenize_str(input, &ctx).unwrap();
         match parse(tz.tokens, &ctx) {

--- a/src/policybinaryv2.rs
+++ b/src/policybinaryv2.rs
@@ -639,7 +639,7 @@ mod test {
             .value("admin")
             .build()
             .unwrap();
-        let attr_tag = Attribute::tag("endpoint.hardened").build().unwrap();
+        let attr_tag = Attribute::tag("device.hardened").build().unwrap();
 
         let key_a = JPKey::new(&[attr_role.clone(), attr_tag.clone()]);
         let key_b = JPKey::new(&[attr_tag, attr_role]);
@@ -721,7 +721,7 @@ mod test {
     fn test_jp_builder_add_provides_appends_and_flags() {
         let mut builder = JPBuilder::default();
         let conditions = vec![
-            Attribute::tuple("endpoint.env")
+            Attribute::tuple("device.env")
                 .single()
                 .value("prod")
                 .build()

--- a/src/ptypes.rs
+++ b/src/ptypes.rs
@@ -58,20 +58,20 @@ impl fmt::Display for FPos {
 /// A parsed "allow" statement.
 ///
 /// Originally this was parsed into three clauses that mapped to a permission
-/// statement: and ENDPOINT cluase, a USER clause and a SERVICE clause.  The
-/// endpoint and user clauses were assumed to be on the LHS of the statment,
-/// and the service clause on the RHS. Think: users on endpoints can access services.
+/// statement: and DEVICE cluase, a USER clause and a SERVICE clause.  The
+/// device and user clauses were assumed to be on the LHS of the statment,
+/// and the service clause on the RHS. Think: users on devices can access services.
 ///
 /// However, over time it has become clear that it is better to think in terms
 /// of CLIENTS and SERVERS.  Clients access services on servers.  Clients are LHS (left hand side) and
 /// serviers are RHS.  Both clients and servers can have attributes in any of the
-/// three classes (user, endpoint, service).  A client may also indicate that
+/// three classes (user, device, service).  A client may also indicate that
 /// it is a service.
 ///
 /// The server side (RHS) must always have at least a service clause.
 ///
 /// Attributes of the classes may not always be in the domain of the class. For example, the
-/// service clause may have endpoint attributes in it.
+/// service clause may have device attributes in it.
 #[derive(Clone, Debug)]
 pub struct AllowClause {
     pub clause_id: usize, // Within a given zpl policy, each allow clause gets a unique id.
@@ -217,7 +217,7 @@ impl fmt::Display for Signal {
 pub enum ClassFlavor {
     #[default]
     Undefined, // they all start here
-    Endpoint,
+    Device,
     User,
     Service,
 }
@@ -225,7 +225,7 @@ pub enum ClassFlavor {
 impl Display for ClassFlavor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ClassFlavor::Endpoint => write!(f, "endpoint"),
+            ClassFlavor::Device => write!(f, "device"),
             ClassFlavor::User => write!(f, "user"),
             ClassFlavor::Service => write!(f, "service"),
             ClassFlavor::Undefined => write!(f, "undefined"),
@@ -236,7 +236,7 @@ impl Display for ClassFlavor {
 impl Into<AttrDomain> for ClassFlavor {
     fn into(self) -> AttrDomain {
         match self {
-            ClassFlavor::Endpoint => AttrDomain::Endpoint,
+            ClassFlavor::Device => AttrDomain::Device,
             ClassFlavor::User => AttrDomain::User,
             ClassFlavor::Service => AttrDomain::Service,
             ClassFlavor::Undefined => AttrDomain::Unspecified,
@@ -245,7 +245,7 @@ impl Into<AttrDomain> for ClassFlavor {
 }
 
 /// A class is created from a ZPL define statement.
-/// There are also three built in classes: user, service, and endpoint.
+/// There are also three built in classes: user, service, and device.
 #[derive(Debug, Clone)]
 pub struct Class {
     pub flavor: ClassFlavor,
@@ -266,7 +266,7 @@ impl Class {
         vec![
             Class::default_user(),
             Class::default_service(),
-            Class::default_endpoint(),
+            Class::default_device(),
             Class::default_visa_service(),
         ]
     }
@@ -309,13 +309,13 @@ impl Class {
             class_id: usize::MAX - 3,
         }
     }
-    pub fn default_endpoint() -> Class {
+    pub fn default_device() -> Class {
         Class {
-            flavor: ClassFlavor::Endpoint,
-            parent: zpl::DEF_CLASS_ENDPOINT_NAME.to_string(),
-            name: zpl::DEF_CLASS_ENDPOINT_NAME.to_string(),
+            flavor: ClassFlavor::Device,
+            parent: zpl::DEF_CLASS_DEVICE_NAME.to_string(),
+            name: zpl::DEF_CLASS_DEVICE_NAME.to_string(),
             aka: None,
-            plural: zpl::DEF_CLASS_ENDPOINT_PLURAL.to_string(),
+            plural: zpl::DEF_CLASS_DEVICE_PLURAL.to_string(),
             pos: FPos { line: 0, col: 0 },
             with_attrs: vec![],
             extensible: true,
@@ -325,7 +325,7 @@ impl Class {
     pub fn is_builtin(&self) -> bool {
         self.name == zpl::DEF_CLASS_USER_NAME
             || self.name == zpl::DEF_CLASS_SERVICE_NAME
-            || self.name == zpl::DEF_CLASS_ENDPOINT_NAME
+            || self.name == zpl::DEF_CLASS_DEVICE_NAME
             || self.name == zpl::DEF_CLASS_VISA_SERVICE_NAME
     }
 

--- a/src/weaver.rs
+++ b/src/weaver.rs
@@ -219,7 +219,7 @@ impl Weaver {
 
             // TODO: User may be able to shoot themselves in the foot here if they add
             // too many attributes to VisaService. May want to consider disallowing
-            // any attributes on the service (but allow on user and endpoint).
+            // any attributes on the service (but allow on user and device).
 
             // The admin access attributes are all the attributes declared on the client side of
             // the clause.
@@ -849,9 +849,9 @@ impl Weaver {
             // Here we collect all attributes -- some will have no values.
             let mut attrs = Vec::new();
 
-            // Grab the LHS endpoint, service and user attributes.
+            // Grab the LHS device, service and user attributes.
             for lhs_class in &ac.client {
-                if lhs_class.flavor == ClassFlavor::Endpoint
+                if lhs_class.flavor == ClassFlavor::Device
                     || lhs_class.flavor == ClassFlavor::User
                     || lhs_class.flavor == ClassFlavor::Service
                 {
@@ -1378,7 +1378,7 @@ mod test {
         zpr_address = "fd5a:5052:90de::1"
         interfaces = [ "in1" ]
         in1.netaddr = "127.0.0.1:5000"
-        provider = [["endpoint.zpr.adapter.cn", "fee"]]
+        provider = [["device.zpr.adapter.cn", "fee"]]
 
         [visa_service]
         dock_node = "n0"
@@ -1389,7 +1389,7 @@ mod test {
 
         [services.foo]
         protocol = "fee"
-        provider = [["endpoint.zpr.adapter.cn", "fee"]]
+        provider = [["device.zpr.adapter.cn", "fee"]]
 
         [services.bar]
         protocol = "fee"
@@ -1433,7 +1433,7 @@ mod test {
             clause_id: 1,
             span: (FPos::default(), FPos::default()),
             client: vec![
-                Clause::new(ClassFlavor::Endpoint, "endpoint", Token::default()),
+                Clause::new(ClassFlavor::Device, "device", Token::default()),
                 Clause::new(ClassFlavor::User, "user", Token::default()),
             ],
             server: vec![Clause::new(ClassFlavor::Service, "foo", Token::default())],
@@ -1478,14 +1478,14 @@ mod test {
         zpr_address = "fd5a:5052:90de::1"
         interfaces = [ "in1" ]
         in1.netaddr = "127.0.0.1:5000"
-        provider = [["endpoint.zpr.adapter.cn", "fee"]]
+        provider = [["device.zpr.adapter.cn", "fee"]]
 
         [visa_service]
         dock_node = "n0"
 
         [trusted_services.bas]
         api = "validation/2"
-        provider = [["endpoint.zpr.adapter.cn", "fee"]]
+        provider = [["device.zpr.adapter.cn", "fee"]]
         returns_attributes = ["id -> user.id", "email -> user.email"]
         identity_attributes = ["id"]
 
@@ -1535,11 +1535,11 @@ mod test {
         let cfg = r#"
         [nodes.n0]
         zpr_address = "fd5a:5052:90de::1"
-        provider = [["endpoint.zpr.adapter.cn", "fee"]]
+        provider = [["device.zpr.adapter.cn", "fee"]]
 
         [trusted_services.bas]
         api = "validation/2"
-        provider = [["endpoint.zpr.adapter.cn", "fee"]]
+        provider = [["device.zpr.adapter.cn", "fee"]]
         returns_attributes = ["id -> user.id"]
         "#;
 

--- a/src/zpl.rs
+++ b/src/zpl.rs
@@ -7,8 +7,8 @@ pub const DEF_CLASS_VISA_SERVICE_PLURAL: &str = "VisaServices";
 pub const DEF_CLASS_USER_NAME: &str = "user";
 pub const DEF_CLASS_USER_PLURAL: &str = "users";
 
-pub const DEF_CLASS_ENDPOINT_NAME: &str = "endpoint";
-pub const DEF_CLASS_ENDPOINT_PLURAL: &str = "endpoints";
+pub const DEF_CLASS_DEVICE_NAME: &str = "device";
+pub const DEF_CLASS_DEVICE_PLURAL: &str = "devices";
 
 pub const DEFAULT_TRUSTED_SERVICE_ID: &str = "default";
 pub const DEFAULT_TRUSTED_SERVICE_API: &str = TS_API_V1;
@@ -21,7 +21,7 @@ pub const ICMP_INTERACTION_ONESHOT: &str = "oneshot";
 
 pub const VISA_SERVICE_CN: &str = "vs.zpr";
 
-pub const DEFAULT_TS_PREFIX: &str = "endpoint.zpr.adapter";
+pub const DEFAULT_TS_PREFIX: &str = "device.zpr.adapter";
 
 pub const DEFAULT_ATTR: &str = "cn";
 
@@ -32,7 +32,7 @@ pub const RESERVED_NODE_IDS: [&'static str; 1] = ["visaservice"];
 pub const VS_SERVICE_NAME: &str = "/zpr/visaservice";
 
 pub const KATTR_ROLE: &str = "zpr.role";
-pub const KATTR_CN: &str = "endpoint.zpr.adapter.cn";
+pub const KATTR_CN: &str = "device.zpr.adapter.cn";
 pub const KATTR_ADDR: &str = "zpr.addr";
 
 /// TODO: Add a "link" default class?

--- a/test-data/config.zplc
+++ b/test-data/config.zplc
@@ -1,7 +1,7 @@
 # minimal config so that we can test parsing the RFC zpl
 
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "fee"]]
+provider = [["device.zpr.adapter.cn", "fee"]]
 zpr_address = "fd5a:5052:90de::1"
 
 [trusted_services.foo]
@@ -12,15 +12,15 @@ returns_attributes = [
   "government -> #user.government",
   "cleared -> #user.cleared", 
   "clearance -> user.clearance", 
-  "managed -> #endpoint.managed", 
+  "managed -> #device.managed", 
   "classified -> #service.classified", 
   "database -> #service.database", 
   "svc-id -> service.svc-id", 
   "service -> service.service", 
-  "mach-type -> endpoint.mach-type", 
+  "mach-type -> device.mach-type", 
   "extnet -> service.external-network-connection", 
   "mach-id -> service.machine-id"]
-provider = [["endpoint.zpr.adapter.cn", "foo"]]
+provider = [["device.zpr.adapter.cn", "foo"]]
 
 [protocols.http]
 l4protocol = "TCP"

--- a/test-data/integ-conform-policy.zpl
+++ b/test-data/integ-conform-policy.zpl
@@ -1,14 +1,14 @@
-define adapter as a endpoint with zpr.adapter.cn.
+define adapter as a device with zpr.adapter.cn.
 
 # Our node offers PING too
-define PingableNode as a service with endpoint.zpr.adapter.cn:'node.zpr.org'.
+define PingableNode as a service with device.zpr.adapter.cn:'node.zpr.org'.
 
 # Three services, all offered by same adapter
-define WebService as a service with endpoint.zpr.adapter.cn:'service.zpr.org'.
-define IPerfService as a service with endpoint.zpr.adapter.cn:'service.zpr.org'.
-define PingableService as a service with endpoint.zpr.adapter.cn:'service.zpr.org'.
+define WebService as a service with device.zpr.adapter.cn:'service.zpr.org'.
+define IPerfService as a service with device.zpr.adapter.cn:'service.zpr.org'.
+define PingableService as a service with device.zpr.adapter.cn:'service.zpr.org'.
 
-define SpecialClient as an adapter with endpoint.zpr.adapter.cn:'client.zpr.org'.
+define SpecialClient as an adapter with device.zpr.adapter.cn:'client.zpr.org'.
 
 # the SpecialClient can access three services
 allow SpecialClient to access WebService.
@@ -18,4 +18,4 @@ allow SpecialClient to access PingableService.
 # any connected adapter can ping the node
 allow adapter to access PingableNode.
 
-allow zpr.adapter.cn:'client.zpr.org' endpoints to access VisaService.
+allow zpr.adapter.cn:'client.zpr.org' devices to access VisaService.

--- a/test-data/integ-conform-policy.zplc
+++ b/test-data/integ-conform-policy.zplc
@@ -10,7 +10,7 @@ order = ["hosts", "dns"]
 "my.service" = "fd5a:5052:1::8080" # ZPR contact addr
 
 [nodes."node.zpr.org"]
-provider = [ ["endpoint.zpr.adapter.cn", "node.zpr.org"] ]
+provider = [ ["device.zpr.adapter.cn", "node.zpr.org"] ]
 zpr_address = "n0.zpr"
 
 [trusted_services.default]

--- a/test-data/integ-v4-1node-2agent-ping.zpl
+++ b/test-data/integ-v4-1node-2agent-ping.zpl
@@ -1,17 +1,17 @@
 # two adapters: they can ping each other
 # One node, one visa service: they can ping each other
 
-define adapter as a endpoint with zpr.adapter.cn.
+define adapter as a device with zpr.adapter.cn.
 
 define A1 as adapter with zpr.adapter.cn:adapter1.
 define A2 as adapter with zpr.adapter.cn:adapter2.
 define Node as adapter with zpr.adapter.cn:node.
 define Vs as adapter with zpr.adapter.cn:'vs.zpr'.
 
-define A1Svc as a service with endpoint.zpr.adapter.cn:adapter1.
-define A2Svc as a service with endpoint.zpr.adapter.cn:adapter2.
-define PingableVs as a service with endpoint.zpr.adapter.cn:'vs.zpr'.
-define PingableNode as a service with endpoint.zpr.adapter.cn:node.
+define A1Svc as a service with device.zpr.adapter.cn:adapter1.
+define A2Svc as a service with device.zpr.adapter.cn:adapter2.
+define PingableVs as a service with device.zpr.adapter.cn:'vs.zpr'.
+define PingableNode as a service with device.zpr.adapter.cn:node.
 
 allow A1 to access A2Svc.
 allow A2 to access A1Svc.
@@ -19,4 +19,4 @@ allow A2 to access A1Svc.
 allow Node to access PingableVs.
 allow Vs to access PingableNode.
 
-allow zpr.adapter.cn:'client.zpr.org' endpoints to access VisaService.
+allow zpr.adapter.cn:'client.zpr.org' devices to access VisaService.

--- a/test-data/integ-v4-1node-2agent-ping.zplc
+++ b/test-data/integ-v4-1node-2agent-ping.zplc
@@ -8,7 +8,7 @@ order = ["hosts", "dns"]
 "n0.overlay" = "10.0.0.1"
 
 [nodes."node"]
-provider = [ [ "endpoint.zpr.adapter.cn", "node" ] ]
+provider = [ [ "device.zpr.adapter.cn", "node" ] ]
 zpr_address = "n0.zpr"
 
 [trusted_services.default]

--- a/test-data/integ-v4-1node-3agent-ping.zpl
+++ b/test-data/integ-v4-1node-3agent-ping.zpl
@@ -1,7 +1,7 @@
 # three adapters: they can ping each other
 # One node, one visa service: they can ping each other
 
-define adapter as a endpoint with zpr.adapter.cn.
+define adapter as a device with zpr.adapter.cn.
 
 define A1 as adapter with zpr.adapter.cn:adapter1.
 define A2 as adapter with zpr.adapter.cn:adapter2.
@@ -9,11 +9,11 @@ define A3 as adapter with zpr.adapter.cn:adapter3.
 define Node as adapter with zpr.adapter.cn:node.
 define Vs as adapter with zpr.adapter.cn:'vs.zpr'.
 
-define A1Svc as a service with endpoint.zpr.adapter.cn:adapter1.
-define A2Svc as a service with endpoint.zpr.adapter.cn:adapter2.
-define A3Svc as a service with endpoint.zpr.adapter.cn:adapter3.
-define PingableVs as a service with endpoint.zpr.adapter.cn:'vs.zpr'.
-define PingableNode as a service with endpoint.zpr.adapter.cn:node.
+define A1Svc as a service with device.zpr.adapter.cn:adapter1.
+define A2Svc as a service with device.zpr.adapter.cn:adapter2.
+define A3Svc as a service with device.zpr.adapter.cn:adapter3.
+define PingableVs as a service with device.zpr.adapter.cn:'vs.zpr'.
+define PingableNode as a service with device.zpr.adapter.cn:node.
 
 allow A1 to access A2Svc.
 allow A1 to access A3Svc.
@@ -27,4 +27,4 @@ allow A3 to access A2Svc.
 allow Node to access PingableVs.
 allow Vs to access PingableNode.
 
-allow zpr.adapter.cn:'client.zpr.org' endpoints to access VisaService.
+allow zpr.adapter.cn:'client.zpr.org' devices to access VisaService.

--- a/test-data/integ-v4-1node-3agent-ping.zplc
+++ b/test-data/integ-v4-1node-3agent-ping.zplc
@@ -8,7 +8,7 @@ order = ["hosts", "dns"]
 "n0.overlay" = "10.0.0.1"
 
 [nodes."node"]
-provider = [ [ "endpoint.zpr.adapter.cn", "node" ] ]
+provider = [ [ "device.zpr.adapter.cn", "node" ] ]
 zpr_address = "n0.zpr"
 
 [trusted_services.default]

--- a/test-data/m3-ping-and-http.zpl
+++ b/test-data/m3-ping-and-http.zpl
@@ -1,15 +1,15 @@
 # Allow a specific adapter to host a service and allow
 # another adapter to access it.
-# Since we don't yet authenticate users, this policy is expressed using endpoints.
+# Since we don't yet authenticate users, this policy is expressed using devices.
 
 
-define adapter as a endpoint with zpr.adapter.cn.
+define adapter as a device with zpr.adapter.cn.
 define GoldenClient as an adapter with zpr.adapter.cn:'client.zpr.org'.
 
-define ZServicePingable as a service with endpoint.zpr.adapter.cn:'service.zpr.org'.
-define ZWebService as a service with endpoint.zpr.adapter.cn:'service.zpr.org'.
+define ZServicePingable as a service with device.zpr.adapter.cn:'service.zpr.org'.
+define ZWebService as a service with device.zpr.adapter.cn:'service.zpr.org'.
 
 allow GoldenClient to access ZServicePingable.
 allow GoldenClient to access ZWebService.
 
-allow zpr.adapter.cn:'client.zpr.org' endpoints to access VisaService.
+allow zpr.adapter.cn:'client.zpr.org' devices to access VisaService.

--- a/test-data/m3-ping-and-http.zplc
+++ b/test-data/m3-ping-and-http.zplc
@@ -10,7 +10,7 @@ order = ["hosts", "dns"]
 "my.service" = "fd5a:5052:1::8080"
 
 [nodes."node.zpr.org"]
-provider = [ ["endpoint.zpr.adapter.cn", "node.zpr.org"]]
+provider = [ ["device.zpr.adapter.cn", "node.zpr.org"]]
 zpr_address = "node0.zpr"
 
 [trusted_services.default] # note that "default" is special

--- a/test-data/m3-ping-only.zpl
+++ b/test-data/m3-ping-only.zpl
@@ -1,11 +1,11 @@
 # Allow a specific agent to ping another specific agent.
-# Since we don't yet authenticate users, this policy is expressed using endpoints.
+# Since we don't yet authenticate users, this policy is expressed using devices.
 
 
-define adapter as a endpoint with zpr.adapter.cn.
+define adapter as a device with zpr.adapter.cn.
 
-define ZServicePingable as a service with endpoint.zpr.adapter.cn:'service.zpr.org'.
+define ZServicePingable as a service with device.zpr.adapter.cn:'service.zpr.org'.
 
 allow zpr.adapter.cn:'client.zpr.org' adapter to access ZServicePingable.
 
-allow zpr.adapter.cn:'client.zpr.org' endpoints to access VisaService.
+allow zpr.adapter.cn:'client.zpr.org' devices to access VisaService.

--- a/test-data/m3-ping-only.zplc
+++ b/test-data/m3-ping-only.zplc
@@ -10,7 +10,7 @@ order = ["hosts", "dns"]
 
 [nodes."node.zpr.org"]
 key = "GExPGh5RE/nKo8WoN8EqknDDNIEjWBL6PZm08Uhvn0w="
-provider = [ ["endpoint.zpr.adapter.cn", "node.zpr.org"]]
+provider = [ ["device.zpr.adapter.cn", "node.zpr.org"]]
 zpr_address = "node0.zpr"
 interfaces = ["in1"]
 in1.netaddr = "node0.overlay:5000"

--- a/test-data/rfc15-001.zpl
+++ b/test-data/rfc15-001.zpl
@@ -1,4 +1,4 @@
-define laptop AKA laptops as endpoint with optional tag managed.
+define laptop AKA laptops as device with optional tag managed.
 
 # Re-written using the 'on' keyword
 allow cleared government users on managed laptops to access

--- a/test-data/rfc15-004-alt.zpl
+++ b/test-data/rfc15-004-alt.zpl
@@ -1,3 +1,3 @@
-# Removed the leading "endpoints with" clause as that is no longer supported.
+# Removed the leading "devices with" clause as that is no longer supported.
 allow clearance:classified government users to access classified
 services.

--- a/test-data/rfc15-005-alt.zpl
+++ b/test-data/rfc15-005-alt.zpl
@@ -1,3 +1,3 @@
-# This had a leading "endpoints with" class but that is not needed and in fact no longer allowed.
+# This had a leading "devices with" class but that is not needed and in fact no longer allowed.
 allow government, clearance:classified users to access
 classified services.

--- a/test-data/rfc15-007-alt.zpl
+++ b/test-data/rfc15-007-alt.zpl
@@ -1,5 +1,5 @@
 define Image-database as a service with svc-id.
 
-# Removed the leading "endpoints with" as that is no longer allowed.
+# Removed the leading "devices with" as that is no longer allowed.
 allow cleared government users to access Image-database.
 

--- a/test-data/rfc15-008-alt.zpl
+++ b/test-data/rfc15-008-alt.zpl
@@ -1,4 +1,4 @@
-define Image-database as a endpoint with mach-type:idb.
+define Image-database as a device with mach-type:idb.
 
 define server as service with machine-id.
 

--- a/test-data/rfc15-008.zpl
+++ b/test-data/rfc15-008.zpl
@@ -1,3 +1,3 @@
-define Image-database as an endpoint with mach-type:idb.
+define Image-database as an device with mach-type:idb.
 define server as service with service.
 allow Image-database to access service:image-database servers.

--- a/test-data/rfc15-013.zpl
+++ b/test-data/rfc15-013.zpl
@@ -1,4 +1,4 @@
-define peripheral as a endpoint with function.
+define peripheral as a device with function.
 
 define mouse AKA mice as peripheral with function:pointing.
 

--- a/test-data/test-bas.zpl
+++ b/test-data/test-bas.zpl
@@ -6,9 +6,9 @@ services.
 define database as a service with user.bas_id:1234.
 define employee as a user with user.bas_id.
 
-allow color:red employees to access classified databases on tint:sales endpoints.
+allow color:red employees to access classified databases on tint:sales devices.
 
-allow endpoint.zpr.adapter.cn: users to access classified services.
+allow device.zpr.adapter.cn: users to access classified services.
 
 
 # FIXME?
@@ -19,17 +19,17 @@ allow endpoint.zpr.adapter.cn: users to access classified services.
 
 define AuthService as a service.
 
-// define AuthService as a service with endpoint.zpr.adapter.cn:'bas.zpr.org'
-// consider "define AuthService as a service on endpoints with cn:'bas.zpr.org'
+// define AuthService as a service with device.zpr.adapter.cn:'bas.zpr.org'
+// consider "define AuthService as a service on devices with cn:'bas.zpr.org'
 
 // ZPL author must explicitly grant access to any authentication
 // services for adapters.
 // Access for the visa service is added by the compiler.
 
-allow zpr.adapter.cn: endpoints to access AuthService.
+allow zpr.adapter.cn: devices to access AuthService.
 
 # In policy you can define "administrators" in any way you want.
-define NetAdmins as users with endpoint.zpr.adapter.cn:'admin.zpr.org'.
+define NetAdmins as users with device.zpr.adapter.cn:'admin.zpr.org'.
 
 # VisaService is a reserved name.
 allow NetAdmins to access VisaService.

--- a/test-data/test-bas.zplc
+++ b/test-data/test-bas.zplc
@@ -1,7 +1,7 @@
 # minimal config so that we can test parsing the RFC zpl
 
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "node.zpr.org"]]
+provider = [["device.zpr.adapter.cn", "node.zpr.org"]]
 zpr_address = "fd5a:5052:90de::1"
 
 [trusted_services.bas]
@@ -9,17 +9,17 @@ api = "validation/2"
 client = "AuthService"
 cert_path = "bas-tls.crt"
 returns_attributes = [ 
-  "tint -> endpoint.tint", 
+  "tint -> device.tint", 
   "color -> user.color", 
   "government -> #user.government",
-  "govpc -> #endpoint.government",
+  "govpc -> #device.government",
   "clearance -> user.clearance", 
   "classified -> #service.classified", 
   "roles -> user.role{}",
   "bas_id -> user.bas_id" 
 ]
 identity_attributes = [ "bas_id" ]
-provider = [[ "endpoint.zpr.adapter.cn", "bas.zpr.org" ]]
+provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
 # Will expect to find two service definitions later:
 #    bas-vs and bas-client
 

--- a/test-data/test-lhs-service.zpl
+++ b/test-data/test-lhs-service.zpl
@@ -1,10 +1,10 @@
 
 Allow red services                                    to access blue services.
-Allow green users                on yellow endpoints  to access blue services on orange endpoints.
-Allow red services               on yellow endpoints  to access blue services on orange endpoints.
-Allow user.green, brown services on yellow endpoints  to access blue services.
-Allow service.brown, green users on yellow endpoints  to access blue services.
-Allow red services                                    to access user.green, blue services on yellow endpoints.
+Allow green users                on yellow devices  to access blue services on orange devices.
+Allow red services               on yellow devices  to access blue services on orange devices.
+Allow user.green, brown services on yellow devices  to access blue services.
+Allow service.brown, green users on yellow devices  to access blue services.
+Allow red services                                    to access user.green, blue services on yellow devices.
 
 
 define MyDb as a service with tag blue.

--- a/test-data/test-lhs-service.zplc
+++ b/test-data/test-lhs-service.zplc
@@ -1,7 +1,7 @@
 # minimal config so that we can test parsing the RFC zpl
 
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "fee"]]
+provider = [["device.zpr.adapter.cn", "fee"]]
 zpr_address = "fd5a:5052:90de::1"
 
 [trusted_services.foo]
@@ -12,9 +12,9 @@ returns_attributes = [
   "blue -> #service.blue", 
   "brown -> #service.brown", 
   "green -> #user.green", 
-  "yellow -> #endpoint.yellow", 
-  "orange -> #endpoint.orange" ]
-provider = [["endpoint.zpr.adapter.cn", "foo"]]
+  "yellow -> #device.yellow", 
+  "orange -> #device.orange" ]
+provider = [["device.zpr.adapter.cn", "foo"]]
 
 [protocols.http]
 l4protocol = "TCP"
@@ -32,8 +32,8 @@ protocol = "zpr-validation2"
 
 [services.MyWeb]
 protocol = "http"
-provider = [[ "endpoint.zpr.adapter.cn", "webserver.zpr" ]]
+provider = [[ "device.zpr.adapter.cn", "webserver.zpr" ]]
 
 [services.MyDb]
 protocol = "dbprot"
-provider = [[ "endpoint.zpr.adapter.cn", "dbserver.zpr" ]]
+provider = [[ "device.zpr.adapter.cn", "dbserver.zpr" ]]

--- a/test-data/test-never.zplc
+++ b/test-data/test-never.zplc
@@ -1,7 +1,7 @@
 # minimal config so that we can test parsing the RFC zpl
 
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "node.zpr.org"]]
+provider = [["device.zpr.adapter.cn", "node.zpr.org"]]
 zpr_address = "fd5a:5052:90de::1"
 
 [trusted_services.bas]
@@ -10,7 +10,7 @@ client = "AuthService"
 cert_path = "bas-tls.crt"
 returns_attributes = [ "color -> user.color", "content -> service.content", "bas_id -> user.bas_id" ]
 identity_attributes = [ "bas_id" ]
-provider = [[ "endpoint.zpr.adapter.cn", "bas.zpr.org" ]]
+provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
 # Will expect to find two service definitions later:
 #    bas-vs and bas-client
 

--- a/test-data/test-on.zpl
+++ b/test-data/test-on.zpl
@@ -2,38 +2,38 @@
 
 define Image-database as a service.
 
-# ON - used for a client endpoint clause
-# In this case the client user is on a secure endpoint.
-allow clearance:classified government users on hardened endpoints to access level:classified services.
+# ON - used for a client device clause
+# In this case the client user is on a secure device.
+allow clearance:classified government users on hardened devices to access level:classified services.
 #___________________________________________↑
 
 # ON - used for a service clause
-# In this case the service is on a secure endpoint.
+# In this case the service is on a secure device.
 
 # First, here is old way that should still work.
-allow clearance:classified government users to access level:classified, endpoint.hardened services.
+allow clearance:classified government users to access level:classified, device.hardened services.
 
 # And here is new way using ON
-allow clearance:classified government users to access level:classified services on encrypted endpoints.
+allow clearance:classified government users to access level:classified services on encrypted devices.
 #_______________________________________________________________________________↑
 
 
-# Now define an endpoint that requires an attribute. And then use that in a
+# Now define an device that requires an attribute. And then use that in a
 # trailing ON clause.
-define LockedEndpoint as an endpoint with tag encrypted.
-allow clearance:classified government users to access level:secret services on LockedEndpoints.
+define LockedDevice as an device with tag encrypted.
+allow clearance:classified government users to access level:secret services on LockedDevices.
 #___________________________________________________________________________↑
 
 
 
 # Defines as usual must use the WITH format.
-define ServiceRequiresEncrypted as an Image-database with tag endpoint.encrypted.
+define ServiceRequiresEncrypted as an Image-database with tag device.encrypted.
 allow clearance:public users to access ServiceRequiresEncrypted.
 
 
 define AuthService as a service.
 
-# Here is an endpoint clause without ON since there is no user clause.
-allow zpr.adapter.cn: endpoints to access AuthService.
-define NetAdmins as users with endpoint.zpr.adapter.cn:'admin.zpr.org'.
+# Here is an device clause without ON since there is no user clause.
+allow zpr.adapter.cn: devices to access AuthService.
+define NetAdmins as users with device.zpr.adapter.cn:'admin.zpr.org'.
 allow NetAdmins to access VisaService.

--- a/test-data/test-on.zplc
+++ b/test-data/test-on.zplc
@@ -1,7 +1,7 @@
 # minimal config so that we can test parsing the RFC zpl
 
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "node.zpr.org"]]
+provider = [["device.zpr.adapter.cn", "node.zpr.org"]]
 zpr_address = "fd5a:5052:90de::1"
 
 
@@ -14,11 +14,11 @@ returns_attributes = [
   "clearance -> user.clearance", 
   "classified -> #user.classified", 
   "bas_id -> user.bas_id", 
-  "hard -> #endpoint.hardened", 
-  "encr -> #endpoint.encrypted", 
+  "hard -> #device.hardened", 
+  "encr -> #device.encrypted", 
   "level -> service.level" ]
 identity_attributes = [ "bas_id" ]
-provider = [[ "endpoint.zpr.adapter.cn", "bas.zpr.org" ]]
+provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
 # Will expect to find two service definitions later:
 #    bas-vs and bas-client
 

--- a/test-data/test-quoted.zpl
+++ b/test-data/test-quoted.zpl
@@ -12,9 +12,9 @@ allow  mostexcellentuser to access mygreatservice.
 
 
 define AuthService as a service.
-allow zpr.adapter.cn: endpoints to access AuthService.
+allow zpr.adapter.cn: devices to access AuthService.
 
-# define NetAdmins as users with endpoint.zpr.adapter.cn:'admin.zpr.org'
+# define NetAdmins as users with device.zpr.adapter.cn:'admin.zpr.org'
 
 # VisaService is a reserved name.
 # allow NetAdmins to access VisaService

--- a/test-data/test-quoted.zplc
+++ b/test-data/test-quoted.zplc
@@ -1,7 +1,7 @@
 # minimal config so that we can test parsing the RFC zpl
 
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "node.zpr.org"]]
+provider = [["device.zpr.adapter.cn", "node.zpr.org"]]
 zpr_address = "fd5a:5052:90de::1"
 
 
@@ -16,7 +16,7 @@ returns_attributes = [
   "classified -> #service.classified", 
   "bas_id -> user.bas_id" ]
 identity_attributes = [ "bas_id" ]
-provider = [[ "endpoint.zpr.adapter.cn", "bas.zpr.org" ]]
+provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
 # Will expect to find two service definitions later:
 #    bas-vs and bas-client
 

--- a/test-data/test-service-attrs.zplc
+++ b/test-data/test-service-attrs.zplc
@@ -1,7 +1,7 @@
 # minimal config so that we can test parsing the RFC zpl
 
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "node.zpr.org"]]
+provider = [["device.zpr.adapter.cn", "node.zpr.org"]]
 zpr_address = "fd5a:5052:90de::1"
 
 
@@ -12,7 +12,7 @@ client = "AuthService"
 cert_path = "bas-tls.crt"
 returns_attributes = [ "color -> user.color", "content -> service.content", "bas_id -> user.bas_id" ]
 identity_attributes = [ "bas_id" ]
-provider = [[ "endpoint.zpr.adapter.cn", "bas.zpr.org" ]]
+provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
 # Will expect to find two service definitions later:
 #    bas-vs and bas-client
 

--- a/test-data/test-setval.zplc
+++ b/test-data/test-setval.zplc
@@ -1,6 +1,6 @@
 
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "node.zpr.org"]]
+provider = [["device.zpr.adapter.cn", "node.zpr.org"]]
 zpr_address = "fd5a:5052:90de::1"
 
 [trusted_services.bas]
@@ -9,7 +9,7 @@ client = "AuthService"
 cert_path = "bas-tls.crt"
 returns_attributes = [ "bas_id -> user.bas_id", "markers -> user.markers{}", "role -> user.role{}", "content -> service.content{}"]
 identity_attributes = [ "bas_id" ]
-provider = [[ "endpoint.zpr.adapter.cn", "bas.zpr.org" ]]
+provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
 # Will expect to find two service definitions later:
 #    bas-vs and bas-client
 

--- a/test-data/test-signal.zpl
+++ b/test-data/test-signal.zpl
@@ -11,6 +11,6 @@ allow employees to access databases and signal "employee"
      to signalService.
 
 # With ON
-allow color:red employees to access databases on tint:sales endpoints and signal "red tint access" to signalService.
+allow color:red employees to access databases on tint:sales devices and signal "red tint access" to signalService.
 
-allow employees on hardened endpoints to access databases and signal "accessed" to signalService.
+allow employees on hardened devices to access databases and signal "accessed" to signalService.

--- a/test-data/test-signal.zplc
+++ b/test-data/test-signal.zplc
@@ -1,7 +1,7 @@
 # minimal config so that we can test parsing the RFC zpl
 
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "node.zpr.org"]]
+provider = [["device.zpr.adapter.cn", "node.zpr.org"]]
 zpr_address = "fd5a:5052:90de::1"
 
 
@@ -9,9 +9,9 @@ zpr_address = "fd5a:5052:90de::1"
 api = "validation/2"
 client = "AuthService"
 cert_path = "bas-tls.crt"
-returns_attributes = [ "tint -> endpoint.tint", "color -> user.color", "bas_id -> user.bas_id", "hard -> #endpoint.hardened" ]
+returns_attributes = [ "tint -> device.tint", "color -> user.color", "bas_id -> user.bas_id", "hard -> #device.hardened" ]
 identity_attributes = [ "bas_id" ]
-provider = [[ "endpoint.zpr.adapter.cn", "bas.zpr.org" ]]
+provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
 # Will expect to find two service definitions later:
 #    bas-vs and bas-client
 

--- a/test-data/test-topo.zplc
+++ b/test-data/test-topo.zplc
@@ -1,12 +1,12 @@
 [nodes.n0]
-provider = [["endpoint.zpr.adapter.cn", "node0.zpr.org"]]
+provider = [["device.zpr.adapter.cn", "node0.zpr.org"]]
 zpr_address = "fd5a:5052:90de::1"
 
 [nodes.n0.substrate_addrs]
 i0 = "10.0.0.1:5000"
 
 [nodes.n1]
-provider = [["endpoint.zpr.adapter.cn", "node1.zpr.org"]]
+provider = [["device.zpr.adapter.cn", "node1.zpr.org"]]
 zpr_address = "fd5a:5052:90de::2"
 
 [nodes.n1.substrate_addrs]
@@ -23,7 +23,7 @@ client = "AuthService"
 cert_path = "bas-tls.crt"
 returns_attributes = [ "color -> user.color", "content -> service.content", "bas_id -> user.bas_id" ]
 identity_attributes = [ "bas_id" ]
-provider = [[ "endpoint.zpr.adapter.cn", "bas.zpr.org" ]]
+provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
 # Will expect to find two service definitions later:
 #    bas-vs and bas-client
 

--- a/test-data/vs-auth-test.zpl
+++ b/test-data/vs-auth-test.zpl
@@ -1,9 +1,9 @@
 # Allow a specific adapter to host a service and allow
 # another adapter to access it.
-# Since we don't yet authenticate users, this policy is expressed using endpoints.
+# Since we don't yet authenticate users, this policy is expressed using devices.
 
 
-define adapter as a endpoint with cn.
+define adapter as a device with cn.
 define GoldenClient as an adapter with cn:'client.zpr.org'.
 
 define ZServicePingable as a service with cn:'service.zpr.org'.
@@ -12,4 +12,4 @@ define ZWebService as a service with cn:'service.zpr.org'.
 allow GoldenClient to access ZServicePingable.
 allow GoldenClient to access ZWebService.
 
-allow zpr.adapter.cn:'client.zpr.org' endpoints to access VisaService.
+allow zpr.adapter.cn:'client.zpr.org' devices to access VisaService.

--- a/zpl.bnf
+++ b/zpl.bnf
@@ -2,15 +2,6 @@
 // allow.rs, define.rs, never.rs). Originally extracted from ZRFC 15, then
 // reconciled against the code.
 //
-// TERMINOLOGY DRIFT — "device" vs "endpoint":
-//   ZRFC 15 uses the term ***device***/***devices*** (with a predefined subclass
-//   ***servers***) for the entity that connects to the ZPRnet. The compiler has
-//   NOT adopted this rename: it still uses the older term "endpoint"/"endpoints"
-//   throughout (TokenType, ClassFlavor::Endpoint, DEF_CLASS_ENDPOINT_NAME, ...).
-//   This BNF follows the CODE, so it uses "endpoint" below. Everywhere you see
-//   <endpoint-spec>, <endpoint-class-name>, "endpoint", or "endpoints", the ZRFC
-//   would say "device"/"devices".
-//
 // NOT YET IMPLEMENTED (documented in ZRFC 15 but absent from the compiler):
 //   - the predefined "servers" class (a subclass of devices with a set-valued
 //     "services" attribute)
@@ -59,11 +50,11 @@
 
 <p-statement> ::= <subject-clause> "to" "access" <object-clause> <signal-clause>?
 
-<subject-clause> ::= <user-spec> | <service-spec> | <endpoint-spec> |
-                     <user-spec> "on" <endpoint-spec> |
-                     <service-spec> "on" <endpoint-spec>
+<subject-clause> ::= <user-spec> | <service-spec> | <device-spec> |
+                     <user-spec> "on" <device-spec> |
+                     <service-spec> "on" <device-spec>
 
-<object-clause> ::= <service-spec> | <service-spec> "on" <endpoint-spec>
+<object-clause> ::= <service-spec> | <service-spec> "on" <device-spec>
 
 // The "and"/"," before "signal" are optional delimiters (consumed but not required).
 // The message may be any <name> (quoting is conventional but not required).
@@ -114,9 +105,9 @@
 // A <user-class-name> must be, or descend from, the built-in "user" class.
 <user-class-name> ::= <name> | <built-in-user-class-name>
 
-<endpoint-spec> ::= (<attribute-expr> | <endpoint-class-name>) (<and-token>? (<attribute-expr> | <endpoint-class-name>))*
-// An <endpoint-class-name> must be, or descend from, the built-in "endpoint" class.
-<endpoint-class-name> ::= <name> | <built-in-endpoint-class-name>
+<device-spec> ::= (<attribute-expr> | <device-class-name>) (<and-token>? (<attribute-expr> | <device-class-name>))*
+// A <device-class-name> must be, or descend from, the built-in "device" class.
+<device-class-name> ::= <name> | <built-in-device-class-name>
 
 <service-spec> ::= (<attribute-expr> | <service-class-name>) (<and-token>? (<attribute-expr> | <service-class-name>))*
 // A <service-class-name> must be, or descend from, the built-in "service" class.
@@ -159,13 +150,12 @@
 
 <class-name> ::= <built-in-class-name> | <name>
 
-<built-in-class-name> ::= <built-in-endpoint-class-name> |
+<built-in-class-name> ::= <built-in-device-class-name> |
                           <built-in-service-class-name> |
                           <built-in-user-class-name>
 
-// ZRFC 15 calls this class "device"/"devices" (with subclass "server"/"servers");
-// the compiler has not yet adopted that rename and only accepts "endpoint"/"endpoints".
-<built-in-endpoint-class-name> ::= "endpoint" | "endpoints"
+// ZRFC 15 also defines a subclass "server"/"servers", not yet implemented.
+<built-in-device-class-name> ::= "device" | "devices"
 
 // "VisaService"/"VisaServices" is a predefined service class (Class::defaults()),
 // but it is NOT extensible: it may not be used as a parent in a define statement.


### PR DESCRIPTION
Switch to use the term "device" instead of "endpoint".

This is a mechanical find/replace to rename the class that was called "endpoint" to one called "device".  Impacts many functions, almost all ZPL and ZPLC files too.

Requires common 0.20.0.
Bumps compiler version to 0.13.0.
