### PR TITLE
Mk/138 ts - Add support for "api=file" trusted service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zplc"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,8 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.20.0"
+version = "0.21.0"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.21.0#b212ca1a81464ee0534161fe6c6c8fd27f6a5b80"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zplc"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zplc"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,4 @@ ring = "0.17.8"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.8"
 toml = "0.9.7"
-# zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.20.0", features = ["policy"] }
-zpr = { path = "../zpr-common", features = ["policy"] }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.21.0", features = ["policy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ ring = "0.17.8"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.8"
 toml = "0.9.7"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.20.0", features = ["policy"] }
+# zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.20.0", features = ["policy"] }
+zpr = { path = "../zpr-common", features = ["policy"] }

--- a/README_ZPLC.md
+++ b/README_ZPLC.md
@@ -104,6 +104,9 @@ For non default trusted services, the field meanings are:
   * `validation/2` - An validation service.  Meaning that the service can provide
      validation of authentication to a visa service, and actor authentication services
      to an adapter.
+  * `file` - A file-backed attribute source offered by the visa service itself, with no
+     network presence. The visa service loads the attributes from a local `<TSNAME>.json`
+     file at runtime. See *File Trusted Services* below.
   * *addition values TBD*
 * `service` - Sets the service ID used in the **services** block for the visa-service
   facing service provided by this trusted service.  This is *optional* and by default
@@ -117,6 +120,13 @@ For non default trusted services, the field meanings are:
   ZPL attribute names.
 * `identity_attributes` - Subset of the `returns_attributes` that denote identity.
 * `provider` - Attribute key/value tuples of the actor (or actors) that provide this service.
+* `expiration_seconds` - Optional lifetime (in seconds) of the attributes this service vouches
+  for. Accepted on `validation/2` and `file` services; rejected on `default`. Must be a
+  non-negative integer that fits in a 32-bit unsigned value. Omitted or `0` means the visa
+  service selects the lifetime at runtime (from the service or its own default).
+
+Every trusted-service ID (the `<TSNAME>`) must match `[A-Za-z0-9_-]+`. For a `file` service this
+ID is also the filename stem — the visa service loads attributes from `<TSNAME>.json`.
 
 
 A trusted service for validation is really two services: the service that the visa service
@@ -147,6 +157,25 @@ port = 4444
 protocol = "zpr-oauthrsa"
 port = 1234
 ```
+
+### File Trusted Services
+
+A `file` trusted service supplies actor attributes from a local JSON file loaded by the visa
+service rather than over the network. Declare only `returns_attributes` (at least one mapping)
+and, optionally, `expiration_seconds`:
+
+```toml
+[trusted_services.attrfile]
+api = "file"
+returns_attributes = ["hair_color -> user.hair_color", "lazy -> #user.lazy"]
+expiration_seconds = 3600
+```
+
+Because a file service has no network presence, the `service`, `client`, `cert_path`, `provider`,
+and `identity_attributes` properties are **not** allowed. The compiler weaves it as a service
+offered by the visa service CN (`vs.zpr`) with no endpoints and no communication policy. The
+attribute mappings use the same `->` syntax (and single / `{}` multi / `#` tag forms) as any other
+trusted service (see *Attributes* below).
 
 ### Attributes
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -144,8 +144,7 @@ pub struct Bootstrap {
 }
 
 /// Trusted Service table ("trusted_services")
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TrustedService {
     pub id: String,
     pub api: String,
@@ -507,9 +506,10 @@ impl ConfigParse {
             trusted_services.push(ts);
         }
         if default_creates == 0 {
-            let returns =
-                vec![parse_attribute_mapping(&format!("{} -> {}", zpl::KATTR_CN, zpl::KATTR_CN))
-                    .unwrap()];
+            let returns = vec![
+                parse_attribute_mapping(&format!("{} -> {}", zpl::KATTR_CN, zpl::KATTR_CN))
+                    .unwrap(),
+            ];
             let ts = TrustedService {
                 id: zpl::DEFAULT_TRUSTED_SERVICE_ID.to_string(),
                 api: zpl::DEFAULT_TRUSTED_SERVICE_API.to_string(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,7 +14,7 @@ use crate::crypto::sha256;
 use crate::errors::CompilationError;
 use crate::protocols::{IcmpFlowType, PortSpec, Protocol, ProtocolError, ZPR_L7_BUILTINS};
 use crate::zpl;
-use zpr::policy_types::Attribute;
+use zpr::policy_types::{AttrMapping, parse_attribute_mapping};
 
 mod node_link;
 mod protocol;
@@ -24,7 +24,7 @@ mod trusted_service;
 use node_link::{parse_link, parse_node, parse_substrate_addrs};
 use protocol::parse_protocol;
 use service::parse_service;
-use trusted_service::parse_trusted_service;
+use trusted_service::{parse_trusted_service, validate_ts_id};
 
 /// Helper to create a ConfigError. Works with a single string (or &str) argument
 /// (really anything that has a to_string function), or with two args: a format string and arguments.
@@ -149,10 +149,11 @@ pub struct Bootstrap {
 pub struct TrustedService {
     pub id: String,
     pub api: String,
+    pub expiration_seconds: u32, // 0 = service/VS default
     pub service: Option<String>, // Name of service for VS operations
     pub client: Option<String>,  // Name of service for client operations
     pub cert_path: Option<PathBuf>,
-    pub returns_attrs: HashMap<String, Attribute>,
+    pub returns_attrs: Vec<AttrMapping>, // ordered service-key -> attribute mappings
     pub identity_attrs: Vec<String>,
     pub provider: Option<Vec<(String, String)>>, // required for non-default
 }
@@ -490,6 +491,7 @@ impl ConfigParse {
         let mut trusted_services = Vec::new();
         let mut default_creates = 0;
         for (ts_id, v) in ts {
+            validate_ts_id(ts_id)?;
             let ts = parse_trusted_service(
                 ts_id,
                 v.as_table()
@@ -505,13 +507,13 @@ impl ConfigParse {
             trusted_services.push(ts);
         }
         if default_creates == 0 {
-            let returns = HashMap::from([(
-                zpl::KATTR_CN.to_string(),
-                Attribute::tuple(zpl::KATTR_CN).single().build().unwrap(),
-            )]);
+            let returns =
+                vec![parse_attribute_mapping(&format!("{} -> {}", zpl::KATTR_CN, zpl::KATTR_CN))
+                    .unwrap()];
             let ts = TrustedService {
                 id: zpl::DEFAULT_TRUSTED_SERVICE_ID.to_string(),
                 api: zpl::DEFAULT_TRUSTED_SERVICE_API.to_string(),
+                expiration_seconds: 0,
                 cert_path: None,
                 returns_attrs: returns,
                 identity_attrs: vec![zpl::KATTR_CN.to_string()],
@@ -1060,10 +1062,8 @@ mod test {
         assert_eq!(ts.api, zpl::DEFAULT_TRUSTED_SERVICE_API);
         assert_eq!(ts.cert_path, Some(PathBuf::from("foo.pem")));
         assert_eq!(ts.returns_attrs.len(), 1);
-        assert_eq!(
-            ts.returns_attrs[zpl::KATTR_CN].zpl_key(),
-            "device.zpr.adapter.cn"
-        );
+        assert_eq!(ts.returns_attrs[0].service_attr_key, zpl::KATTR_CN);
+        assert_eq!(ts.returns_attrs[0].attr.zpl_key(), "device.zpr.adapter.cn");
         assert_eq!(ts.identity_attrs.len(), 1);
         assert_eq!(ts.identity_attrs[0], "device.zpr.adapter.cn");
     }
@@ -1113,8 +1113,16 @@ mod test {
         assert_eq!(ts.api, "validation/2");
         assert_eq!(ts.cert_path, Some(PathBuf::from("foo.pem")));
         assert_eq!(ts.returns_attrs.len(), 2);
-        assert_eq!(ts.returns_attrs["a"].zpl_key(), "user.a");
-        assert_eq!(ts.returns_attrs["c"].zpl_key(), "user.c");
+        let get = |k: &str| {
+            ts.returns_attrs
+                .iter()
+                .find(|m| m.service_attr_key == k)
+                .unwrap()
+                .attr
+                .zpl_key()
+        };
+        assert_eq!(get("a"), "user.a");
+        assert_eq!(get("c"), "user.c");
         assert_eq!(ts.identity_attrs.len(), 1);
         assert!(ts.identity_attrs[0] == "c");
     }

--- a/src/config/trusted_service.rs
+++ b/src/config/trusted_service.rs
@@ -196,6 +196,11 @@ pub(super) fn parse_trusted_service(
     let expiration_seconds = parse_expiration_seconds(ts, ts_id, is_default)?;
 
     if api == zpl::TS_API_FILE {
+        if is_default {
+            return Err(err_config!(
+                "default trusted_service cannot have api \"file\""
+            ));
+        }
         return parse_file_trusted_service(ts_id, ts, expiration_seconds);
     }
 

--- a/src/config/trusted_service.rs
+++ b/src/config/trusted_service.rs
@@ -112,8 +112,8 @@ fn parse_return_mappings(
     let mut seen: HashSet<String> = HashSet::new();
     let mut out = Vec::new();
     for ra in raw {
-        let m =
-            parse_attribute_mapping(ra).map_err(|e| err_config!("trusted_service {}: {}", ts_id, e))?;
+        let m = parse_attribute_mapping(ra)
+            .map_err(|e| err_config!("trusted_service {}: {}", ts_id, e))?;
         if !seen.insert(m.service_attr_key.clone()) {
             return Err(err_config!(
                 "trusted_service {} contains duplicate service attribute name '{}'",
@@ -166,13 +166,9 @@ fn parse_file_trusted_service(
     Ok(TrustedService {
         id: ts_id.to_string(),
         api: zpl::TS_API_FILE.to_string(),
-        expiration_seconds,
-        cert_path: None,
-        returns_attrs,
-        identity_attrs: Vec::new(),
-        provider: None,
-        client: None,
-        service: None,
+        expiration_seconds: expiration_seconds,
+        returns_attrs: returns_attrs,
+        ..Default::default()
     })
 }
 
@@ -415,7 +411,10 @@ mod test {
     fn test_file_requires_returns_attributes() {
         let t = body("api = \"file\"\n");
         let err = parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap_err();
-        assert!(err.to_string().contains("requires returns_attributes"), "{err}");
+        assert!(
+            err.to_string().contains("requires returns_attributes"),
+            "{err}"
+        );
 
         let t = body("api = \"file\"\nreturns_attributes = []\n");
         let err = parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap_err();
@@ -440,7 +439,8 @@ mod test {
         let t = body("expiration_seconds = 10\ncert_path = \"foo.pem\"\n");
         let err = parse_trusted_service("default", &t, &CompilationCtx::default()).unwrap_err();
         assert!(
-            err.to_string().contains("does not allow expiration_seconds"),
+            err.to_string()
+                .contains("does not allow expiration_seconds"),
             "{err}"
         );
     }
@@ -450,7 +450,10 @@ mod test {
         assert!(validate_ts_id("attrfile").is_ok());
         assert!(validate_ts_id("bas-1_2").is_ok());
         for bad in ["", "bad id", "a/b", "..", "café", "a.b"] {
-            assert!(validate_ts_id(bad).is_err(), "expected {bad:?} to be rejected");
+            assert!(
+                validate_ts_id(bad).is_err(),
+                "expected {bad:?} to be rejected"
+            );
         }
     }
 }

--- a/src/config/trusted_service.rs
+++ b/src/config/trusted_service.rs
@@ -1,10 +1,10 @@
 //! Parser for the `trusted_services` TOML section and its attribute-mapping syntax.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use toml::Table;
-use zpr::policy_types::Attribute;
+use zpr::policy_types::{AttrMapping, parse_attribute_mapping};
 
 use crate::context::CompilationCtx;
 use crate::err_config;
@@ -24,10 +24,27 @@ fn warn_unknown_ts_property(ts: &Table, ctx: &CompilationCtx) -> Result<(), Comp
             "provider" => (),
             "prefix" => (),
             "identity_attributes" => (),
+            "expiration_seconds" => (),
             _ => ctx.warn(&format!(
                 "unknown property '{elem}' detected while parsing trusted_services",
             ))?,
         }
+    }
+    Ok(())
+}
+
+/// Validate a trusted-service TOML id. It must match `[A-Za-z0-9_-]+` so it can be used
+/// unchanged as both a policy `Service.id` and the `<serviceId>.json` filename stem.
+pub(super) fn validate_ts_id(ts_id: &str) -> Result<(), CompilationError> {
+    if ts_id.is_empty()
+        || !ts_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(err_config!(
+            "trusted_service id '{}' is invalid; must match [A-Za-z0-9_-]+",
+            ts_id
+        ));
     }
     Ok(())
 }
@@ -51,6 +68,114 @@ fn parse_string_array(ts: &Table, key: &str, ctx: &str) -> Result<Vec<String>, C
     Ok(ret)
 }
 
+/// Parse the `expiration_seconds` property: default `0`, must be a non-negative TOML integer
+/// that fits in `u32`. Rejected outright on the builtin `default` service.
+fn parse_expiration_seconds(
+    ts: &Table,
+    ts_id: &str,
+    is_default: bool,
+) -> Result<u32, CompilationError> {
+    if !ts.contains_key("expiration_seconds") {
+        return Ok(0);
+    }
+    if is_default {
+        return Err(err_config!(
+            "default trusted_service does not allow expiration_seconds"
+        ));
+    }
+    // `as_integer` rejects strings, floats, and booleans.
+    let v = ts["expiration_seconds"].as_integer().ok_or(err_config!(
+        "trusted_service {} expiration_seconds must be a non-negative integer",
+        ts_id
+    ))?;
+    if v < 0 {
+        return Err(err_config!(
+            "trusted_service {} expiration_seconds must be non-negative",
+            ts_id
+        ));
+    }
+    u32::try_from(v).map_err(|_| {
+        err_config!(
+            "trusted_service {} expiration_seconds {} exceeds u32 range",
+            ts_id,
+            v
+        )
+    })
+}
+
+/// Parse each `"<service-key> -> <attr-spec>"` string into an ordered `Vec<AttrMapping>`,
+/// rejecting duplicate service keys via a temporary set (no parallel map retained).
+fn parse_return_mappings(
+    ts_id: &str,
+    raw: &[String],
+) -> Result<Vec<AttrMapping>, CompilationError> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out = Vec::new();
+    for ra in raw {
+        let m =
+            parse_attribute_mapping(ra).map_err(|e| err_config!("trusted_service {}: {}", ts_id, e))?;
+        if !seen.insert(m.service_attr_key.clone()) {
+            return Err(err_config!(
+                "trusted_service {} contains duplicate service attribute name '{}'",
+                ts_id,
+                m.service_attr_key
+            ));
+        }
+        out.push(m);
+    }
+    Ok(out)
+}
+
+/// A `file` service has no network presence: no provider, client/service interfaces, or cert.
+/// It only declares `returns_attributes` (>= 1 mapping) and optional `expiration_seconds`.
+fn parse_file_trusted_service(
+    ts_id: &str,
+    ts: &Table,
+    expiration_seconds: u32,
+) -> Result<TrustedService, CompilationError> {
+    for forbidden in [
+        "identity_attributes",
+        "provider",
+        "client",
+        "service",
+        "cert_path",
+        "prefix",
+    ] {
+        if ts.contains_key(forbidden) {
+            return Err(err_config!(
+                "trusted_service {} with api \"file\" does not allow property '{}'",
+                ts_id,
+                forbidden
+            ));
+        }
+    }
+    if !ts.contains_key("returns_attributes") {
+        return Err(err_config!(
+            "trusted_service {} with api \"file\" requires returns_attributes",
+            ts_id
+        ));
+    }
+    let raw = parse_string_array(ts, "returns_attributes", "trusted_service")?;
+    let returns_attrs = parse_return_mappings(ts_id, &raw)?;
+    if returns_attrs.is_empty() {
+        return Err(err_config!(
+            "trusted_service {} with api \"file\" requires at least one returns_attributes mapping",
+            ts_id
+        ));
+    }
+    Ok(TrustedService {
+        id: ts_id.to_string(),
+        api: zpl::TS_API_FILE.to_string(),
+        expiration_seconds,
+        cert_path: None,
+        returns_attrs,
+        identity_attrs: Vec::new(),
+        provider: None,
+        client: None,
+        service: None,
+    })
+}
+
 // Parse an individual trusted_service table.
 pub(super) fn parse_trusted_service(
     ts_id: &str,
@@ -71,6 +196,13 @@ pub(super) fn parse_trusted_service(
     } else {
         return Err(err_config!("trusted_service {} missing api", ts_id));
     };
+
+    let expiration_seconds = parse_expiration_seconds(ts, ts_id, is_default)?;
+
+    if api == zpl::TS_API_FILE {
+        return parse_file_trusted_service(ts_id, ts, expiration_seconds);
+    }
+
     let cert_path = if ts.contains_key("cert_path") {
         Some(PathBuf::from(ts["cert_path"].as_str().ok_or(
             err_config!("trusted_service {} cert_path is not a string", ts_id),
@@ -83,13 +215,13 @@ pub(super) fn parse_trusted_service(
         None
     };
 
-    let returns_attrs: Vec<String>;
-    let identity_attrs: Vec<String>;
+    let returns_raw: Vec<String>;
+    let identity_raw: Vec<String>;
     let client_svc: Option<String>;
     let service_svc: Option<String>;
     if !is_default {
-        returns_attrs = parse_string_array(ts, "returns_attributes", "trusted_service")?;
-        identity_attrs = parse_string_array(ts, "identity_attributes", "trusted_service")?;
+        returns_raw = parse_string_array(ts, "returns_attributes", "trusted_service")?;
+        identity_raw = parse_string_array(ts, "identity_attributes", "trusted_service")?;
 
         if ts.contains_key("client") {
             client_svc = Some(
@@ -122,205 +254,203 @@ pub(super) fn parse_trusted_service(
                 "default trusted_service does not allow custom identity_attributes"
             ));
         }
-        returns_attrs = vec![format!("{} -> {}", zpl::KATTR_CN, zpl::KATTR_CN)];
-        identity_attrs = vec![String::from(zpl::KATTR_CN)];
+        returns_raw = vec![format!("{} -> {}", zpl::KATTR_CN, zpl::KATTR_CN)];
+        identity_raw = vec![String::from(zpl::KATTR_CN)];
         client_svc = None;
         service_svc = None;
     }
 
-    let mut returns = HashMap::new();
-    for ra in &returns_attrs {
-        let (service_key_name, zpr_attr) = parse_attribute_mapping(ra)?;
-        if returns.contains_key(&service_key_name) {
-            return Err(err_config!(
-                "trusted_service {} contains duplicate service attribute name '{}'",
-                ts_id,
-                service_key_name
-            ));
-        }
-        returns.insert(service_key_name, zpr_attr);
-    }
+    let returns_attrs = parse_return_mappings(ts_id, &returns_raw)?;
 
-    let mut idents = Vec::new();
-    for ra in &identity_attrs {
+    let mut identity_attrs = Vec::new();
+    for ra in &identity_raw {
         // The ident attribute (for now) must exist in the returns attributes.
-        if !returns.contains_key(ra) {
+        if !returns_attrs.iter().any(|m| &m.service_attr_key == ra) {
             return Err(err_config!(
                 "trusted_service {} identity attribute '{}' not in returns_attributes",
                 ts_id,
                 ra
             ));
         }
-        idents.push(ra.to_string());
+        identity_attrs.push(ra.to_string());
     }
 
     let provider = if ts.contains_key("provider") {
         Some(parse_provider(&format!("trusted_service {ts_id}"), ts)?)
+    } else if !is_default {
+        return Err(err_config!("trusted_service {} missing provider", ts_id));
     } else {
-        if !is_default {
-            return Err(err_config!("trusted_service {} missing provider", ts_id));
-        }
         None
     };
 
     Ok(TrustedService {
         id: ts_id.to_string(),
         api,
+        expiration_seconds,
         cert_path,
-        returns_attrs: returns,
-        identity_attrs: idents,
+        returns_attrs,
+        identity_attrs,
         provider,
         client: client_svc,
         service: service_svc,
     })
 }
 
-/// The mapping string format is "<service-key-name> -> <attribute-spec>" where attribute
-/// spec is:
-///   - <class-name>.<attribute-name> for a regular single value attribute.
-///   - #<class-name>.<attribute-name> for a tag attribute.
-///   - <class-name>.<attribute-name>{} for a multi-valued attribute.
-///
-/// Note that we never use "optional" flag in ZPLC.
-pub(super) fn parse_attribute_mapping(
-    mapping: &str,
-) -> Result<(String, Attribute), CompilationError> {
-    let parts: Vec<&str> = mapping.split("->").collect();
-    if parts.len() != 2 {
-        return Err(err_config!(
-            "invalid attribute mapping '{}', must be of the form '<service-key-name> -> <attribute-spec>'",
-            mapping
-        ));
-    }
-    let service_key_name = parts[0].trim().to_string();
-    let attr_spec = parts[1].trim();
-
-    let zpr_attr = if let Some(stripped) = attr_spec.strip_prefix("#") {
-        Attribute::tag(stripped).build()?
-    } else if let Some(stripped) = attr_spec.strip_suffix("{}") {
-        Attribute::tuple(stripped).multi().build()?
-    } else {
-        Attribute::tuple(attr_spec).single().build()?
-    };
-
-    // In theory we can support any attribute names if they are quoted.
-    // But until we support that on VS we will not permit some characters
-    // here.
-    let valid_chars: HashSet<char> =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-./"
-            .chars()
-            .collect();
-    for c in zpr_attr.zpl_key().chars() {
-        if !valid_chars.contains(&c) {
-            return Err(err_config!(
-                "invalid attribute name '{}' in mapping '{}', contains invalid character '{}'",
-                zpr_attr.zpl_key(),
-                mapping,
-                c
-            ));
-        }
-    }
-
-    Ok((service_key_name, zpr_attr))
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use zpr::policy_types::AttrDomain;
 
-    #[test]
-    fn test_parse_attribute_mapping_tag() {
-        let mapping = "service_key -> #device.tag";
-        let result = parse_attribute_mapping(mapping);
+    fn body(s: &str) -> Table {
+        s.parse::<Table>().unwrap()
+    }
 
-        assert!(result.is_ok());
-        let (service_key_name, attr) = result.unwrap();
-
-        assert_eq!(service_key_name, "service_key");
-        assert_eq!(*attr.get_domain_ref(), AttrDomain::Device);
-        assert_eq!(attr.zpl_value(), "device.tag");
-        assert_eq!(attr.get_values(), None);
-        assert_eq!(attr.is_multi_valued(), false);
-        assert_eq!(attr.is_tag(), true);
-        assert_eq!(attr.optional, false);
+    fn find<'a>(ts: &'a TrustedService, key: &str) -> &'a AttrMapping {
+        ts.returns_attrs
+            .iter()
+            .find(|m| m.service_attr_key == key)
+            .unwrap()
     }
 
     #[test]
-    fn test_parse_attribute_mapping_multi_valued() {
-        let mapping = "service_key -> user.groups{}";
-        let result = parse_attribute_mapping(mapping);
-
-        assert!(result.is_ok());
-        let (service_key_name, attr) = result.unwrap();
-
-        assert_eq!(service_key_name, "service_key");
-        assert_eq!(*attr.get_domain_ref(), AttrDomain::User);
-        assert_eq!(attr.zpl_key(), "user.groups");
-        assert_eq!(attr.get_values(), None);
-        assert_eq!(attr.is_multi_valued(), true);
-        assert_eq!(attr.is_tag(), false);
-        assert_eq!(attr.optional, false);
+    fn test_file_service_ordered_mappings_default_expiration() {
+        let t = body(
+            r#"
+            api = "file"
+            returns_attributes = ["color -> user.color", "hair -> #device.tag", "groups -> user.groups{}"]
+            "#,
+        );
+        let ts = parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap();
+        assert_eq!(ts.api, zpl::TS_API_FILE);
+        assert_eq!(ts.expiration_seconds, 0);
+        assert!(ts.identity_attrs.is_empty());
+        assert!(ts.provider.is_none());
+        // declaration order preserved with exact trimmed RHS spelling
+        let keys: Vec<&str> = ts
+            .returns_attrs
+            .iter()
+            .map(|m| m.service_attr_key.as_str())
+            .collect();
+        assert_eq!(keys, vec!["color", "hair", "groups"]);
+        assert_eq!(find(&ts, "hair").zpr_attr_spec, "#device.tag");
+        assert_eq!(find(&ts, "groups").zpr_attr_spec, "user.groups{}");
     }
 
     #[test]
-    fn test_parse_attribute_mapping_single_valued() {
-        let mapping = "service_key -> service.role";
-        let result = parse_attribute_mapping(mapping);
-
-        assert!(result.is_ok());
-        let (service_key_name, attr) = result.unwrap();
-
-        assert_eq!(service_key_name, "service_key");
-        assert_eq!(*attr.get_domain_ref(), AttrDomain::Service);
-        assert_eq!(attr.zpl_key(), "service.role");
-        assert_eq!(attr.get_values(), None);
-        assert_eq!(attr.is_multi_valued(), false);
-        assert_eq!(attr.is_tag(), false);
-        assert_eq!(attr.optional, false);
+    fn test_file_service_positive_expiration() {
+        let t = body(
+            r#"
+            api = "file"
+            expiration_seconds = 3600
+            returns_attributes = ["color -> user.color"]
+            "#,
+        );
+        let ts = parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap();
+        assert_eq!(ts.expiration_seconds, 3600);
     }
 
     #[test]
-    fn test_parse_attribute_mapping_invalid_format() {
-        let mapping = "invalid_format";
-        let result = parse_attribute_mapping(mapping);
+    fn test_expiration_negative_rejected() {
+        let t = body(
+            r#"
+            api = "file"
+            expiration_seconds = -1
+            returns_attributes = ["color -> user.color"]
+            "#,
+        );
+        let err = parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap_err();
+        assert!(err.to_string().contains("non-negative"), "{err}");
+    }
 
-        assert!(result.is_err());
-        if let Err(CompilationError::ConfigError(msg)) = result {
-            assert!(msg.contains("invalid attribute mapping"));
-            assert!(msg.contains("must be of the form"));
-        } else {
-            panic!("Expected ConfigError");
+    #[test]
+    fn test_expiration_overflow_rejected() {
+        let t = body(
+            r#"
+            api = "file"
+            expiration_seconds = 4294967296
+            returns_attributes = ["color -> user.color"]
+            "#,
+        );
+        let err = parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap_err();
+        assert!(err.to_string().contains("exceeds u32"), "{err}");
+    }
+
+    #[test]
+    fn test_expiration_wrong_types_rejected() {
+        for val in ["\"3600\"", "3.5", "true"] {
+            let t = body(&format!(
+                "api = \"file\"\nexpiration_seconds = {val}\nreturns_attributes = [\"color -> user.color\"]\n"
+            ));
+            let err =
+                parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap_err();
+            assert!(
+                err.to_string().contains("must be a non-negative integer"),
+                "value {val} gave: {err}"
+            );
         }
     }
 
     #[test]
-    fn test_parse_attribute_mapping_whitespace_handling() {
-        let mapping = "  service_key  ->  user.name  ";
-        let result = parse_attribute_mapping(mapping);
-
-        assert!(result.is_ok());
-        let (service_key_name, attr) = result.unwrap();
-
-        assert_eq!(service_key_name, "service_key");
-        assert_eq!(*attr.get_domain_ref(), AttrDomain::User);
-        assert_eq!(attr.zpl_key(), "user.name");
-        assert_eq!(attr.get_values(), None);
-        assert_eq!(attr.is_multi_valued(), false);
-        assert_eq!(attr.is_tag(), false);
-        assert_eq!(attr.optional, false);
+    fn test_file_forbidden_properties_rejected() {
+        for (prop, line) in [
+            ("identity_attributes", "identity_attributes = [\"color\"]"),
+            ("provider", "provider = [[\"foo\", \"bar\"]]"),
+            ("client", "client = \"c\""),
+            ("service", "service = \"s\""),
+            ("cert_path", "cert_path = \"x.pem\""),
+            ("prefix", "prefix = \"bar.hop\""),
+        ] {
+            let t = body(&format!(
+                "api = \"file\"\nreturns_attributes = [\"color -> user.color\"]\n{line}\n"
+            ));
+            let err =
+                parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap_err();
+            assert!(
+                err.to_string().contains(prop) && err.to_string().contains("does not allow"),
+                "property {prop} gave: {err}"
+            );
+        }
     }
 
     #[test]
-    fn test_parse_attribute_mapping_too_many_arrows() {
-        let mapping = "key -> attr -> extra";
-        let result = parse_attribute_mapping(mapping);
+    fn test_file_requires_returns_attributes() {
+        let t = body("api = \"file\"\n");
+        let err = parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap_err();
+        assert!(err.to_string().contains("requires returns_attributes"), "{err}");
 
-        assert!(result.is_err());
-        if let Err(CompilationError::ConfigError(msg)) = result {
-            assert!(msg.contains("invalid attribute mapping"));
-        } else {
-            panic!("Expected ConfigError");
+        let t = body("api = \"file\"\nreturns_attributes = []\n");
+        let err = parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap_err();
+        assert!(err.to_string().contains("at least one"), "{err}");
+    }
+
+    #[test]
+    fn test_file_duplicate_service_key_rejected() {
+        let t = body(
+            r#"
+            api = "file"
+            returns_attributes = ["color -> user.color", "color -> #device.tag"]
+            "#,
+        );
+        let err = parse_trusted_service("attrfile", &t, &CompilationCtx::default()).unwrap_err();
+        assert!(err.to_string().contains("duplicate"), "{err}");
+    }
+
+    #[test]
+    fn test_expiration_on_default_rejected() {
+        // id "default" with no api => builtin default; expiration is not allowed.
+        let t = body("expiration_seconds = 10\ncert_path = \"foo.pem\"\n");
+        let err = parse_trusted_service("default", &t, &CompilationCtx::default()).unwrap_err();
+        assert!(
+            err.to_string().contains("does not allow expiration_seconds"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_ts_id() {
+        assert!(validate_ts_id("attrfile").is_ok());
+        assert!(validate_ts_id("bas-1_2").is_ok());
+        for bad in ["", "bad id", "a/b", "..", "café", "a.b"] {
+            assert!(validate_ts_id(bad).is_err(), "expected {bad:?} to be rejected");
         }
     }
 }

--- a/src/config_api.rs
+++ b/src/config_api.rs
@@ -575,7 +575,12 @@ impl ConfigApi {
             // TODO: Just like when parsing config, we need a notation to express the attribute properties.
             // Eg, multi-value or tag, required or optional.
             // For now we assume all attributes are tuple-type.
-            "attributes" => Some(ConfigItem::AttributeMap(svc.returns_attrs.clone())),
+            "attributes" => Some(ConfigItem::AttributeMap(
+                svc.returns_attrs
+                    .iter()
+                    .map(|m| (m.service_attr_key.clone(), m.attr.clone()))
+                    .collect(),
+            )),
             "id_attributes" => Some(ConfigItem::KeySet(svc.identity_attrs.clone())),
             _ => panic!("unknown key {}", key),
         }

--- a/src/config_api.rs
+++ b/src/config_api.rs
@@ -5,7 +5,6 @@
 use base64::prelude::*;
 use colored::Colorize;
 use core::fmt;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::config::{self, Config};
@@ -13,7 +12,7 @@ use crate::context::CompilationCtx;
 use crate::crypto::{digest_as_hex, load_asn1data_from_pem, load_rsa_public_key};
 use crate::errors::CompilationError;
 use crate::protocols::{IanaProtocol, IcmpFlowType, PortSpec, Protocol};
-use zpr::policy_types::Attribute;
+use zpr::policy_types::AttrMapping;
 
 /// ConfigApi wraps a pseudo RESTFUL api around the config data.
 /// Access is visa the [ConfigApi::get] method.
@@ -112,7 +111,11 @@ pub enum ConfigItem {
     /// A set of key values (eg, a set of node IDs)
     KeySet(Vec<String>),
 
-    AttributeMap(HashMap<String, Attribute>),
+    /// An unsigned 32-bit value (eg, a trusted service's expiration_seconds).
+    U32(u32),
+
+    /// Ordered trusted-service return-attribute mappings.
+    AttrMappings(Vec<AttrMapping>),
 
     /// A set of attributes as key value pairs
     AttrList(Vec<(String, String)>),
@@ -142,16 +145,17 @@ impl fmt::Display for ConfigItem {
                 }
                 write!(f, "]")
             }
-            ConfigItem::AttributeMap(attrs) => {
+            ConfigItem::U32(n) => write!(f, "{}", n),
+            ConfigItem::AttrMappings(mappings) => {
                 let mut first = true;
                 write!(f, "[")?;
-                for (k, v) in attrs {
+                for m in mappings {
                     if first {
                         first = false;
                     } else {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", k, v.to_schema_string())?;
+                    write!(f, "{}: {}", m.service_attr_key, m.zpr_attr_spec)?;
                 }
                 write!(f, "]")
             }
@@ -401,10 +405,17 @@ impl ConfigApi {
         }
     }
 
-    pub fn must_get_attr_map(&self, key: &str) -> HashMap<String, Attribute> {
+    pub fn must_get_u32(&self, key: &str) -> u32 {
         match self.must_get(key) {
-            ConfigItem::AttributeMap(map) => map,
-            _ => panic!("not an AttributeMap"),
+            ConfigItem::U32(v) => v,
+            _ => panic!("not a U32"),
+        }
+    }
+
+    pub fn must_get_attr_mappings(&self, key: &str) -> Vec<AttrMapping> {
+        match self.must_get(key) {
+            ConfigItem::AttrMappings(mappings) => mappings,
+            _ => panic!("not AttrMappings"),
         }
     }
 
@@ -572,15 +583,10 @@ impl ConfigApi {
                 Some(provider) => Some(ConfigItem::AttrList(provider.clone())),
                 None => None,
             },
-            // TODO: Just like when parsing config, we need a notation to express the attribute properties.
-            // Eg, multi-value or tag, required or optional.
-            // For now we assume all attributes are tuple-type.
-            "attributes" => Some(ConfigItem::AttributeMap(
-                svc.returns_attrs
-                    .iter()
-                    .map(|m| (m.service_attr_key.clone(), m.attr.clone()))
-                    .collect(),
-            )),
+            "expiration_seconds" => Some(ConfigItem::U32(svc.expiration_seconds)),
+            // Ordered service-key -> attribute-spec mappings; consumers read `mapping.attr`
+            // for the decoded form.
+            "attributes" => Some(ConfigItem::AttrMappings(svc.returns_attrs.clone())),
             "id_attributes" => Some(ConfigItem::KeySet(svc.identity_attrs.clone())),
             _ => panic!("unknown key {}", key),
         }

--- a/src/dumpv2.rs
+++ b/src/dumpv2.rs
@@ -257,6 +257,47 @@ pub fn dump_v2(fname: &str, encoded_buf: Bytes) {
             println!();
         }
     }
+    if policy.has_trusted_services() {
+        dump::print_section_hdr("TRUSTED SERVICES");
+        for (i, ts_rdr) in policy.get_trusted_services().unwrap().iter().enumerate() {
+            // Decode via the shared TryFrom so the display shares the VS's decode path.
+            match TrustedService::try_from(ts_rdr) {
+                Ok(ts) => {
+                    let expiration = if ts.expiration_seconds == 0 {
+                        "0 (runtime default)".to_string()
+                    } else {
+                        format!("{}s", ts.expiration_seconds)
+                    };
+                    println!(
+                        "{} {}  expiration: {}",
+                        format!("{:02}", i + 1).dimmed(),
+                        ts.service_id.yellow(),
+                        expiration.yellow()
+                    );
+                    for m in &ts.returns_attrs {
+                        println!(
+                            "         {} {} -> {}",
+                            format!("{}", "󰞘").dimmed(),
+                            m.service_attr_key.yellow(),
+                            m.zpr_attr_spec.green()
+                        );
+                    }
+                    if !ts.identity_attrs.is_empty() {
+                        println!("       identity: {}", ts.identity_attrs.join(", ").yellow());
+                    }
+                }
+                Err(e) => {
+                    println!(
+                        "{} {} {}",
+                        format!("{:02}", i + 1).dimmed(),
+                        "(invalid)".red(),
+                        format!("{}", e).red()
+                    );
+                }
+            }
+            println!();
+        }
+    }
     if policy.has_keys() {
         dump::print_section_hdr("KEYS");
         for (i, key) in policy.get_keys().unwrap().iter().enumerate() {
@@ -304,47 +345,6 @@ pub fn dump_v2(fname: &str, encoded_buf: Bytes) {
                     }
                 }
             }
-        }
-    }
-    if policy.has_trusted_services() {
-        dump::print_section_hdr("TRUSTED SERVICES");
-        for (i, ts_rdr) in policy.get_trusted_services().unwrap().iter().enumerate() {
-            // Decode via the shared TryFrom so the display shares the VS's decode path.
-            match TrustedService::try_from(ts_rdr) {
-                Ok(ts) => {
-                    let expiration = if ts.expiration_seconds == 0 {
-                        "0 (runtime default)".to_string()
-                    } else {
-                        format!("{}s", ts.expiration_seconds)
-                    };
-                    println!(
-                        "{} {}  expiration: {}",
-                        format!("{:02}", i + 1).dimmed(),
-                        ts.service_id.yellow(),
-                        expiration.yellow()
-                    );
-                    for m in &ts.returns_attrs {
-                        println!(
-                            "         {} {} -> {}",
-                            format!("{}", "󰞘").dimmed(),
-                            m.service_attr_key.yellow(),
-                            m.zpr_attr_spec.green()
-                        );
-                    }
-                    if !ts.identity_attrs.is_empty() {
-                        println!("       identity: {}", ts.identity_attrs.join(", ").yellow());
-                    }
-                }
-                Err(e) => {
-                    println!(
-                        "{} {} {}",
-                        format!("{:02}", i + 1).dimmed(),
-                        "(invalid)".red(),
-                        format!("{}", e).red()
-                    );
-                }
-            }
-            println!();
         }
     }
 }

--- a/src/dumpv2.rs
+++ b/src/dumpv2.rs
@@ -4,7 +4,7 @@ use openssl::rsa::Rsa;
 use std::convert::TryInto;
 
 use zpr::policy::v1 as policy_capnp;
-use zpr::policy_types::{AttrExp, AttrOp, Peering};
+use zpr::policy_types::{AttrExp, AttrOp, Peering, TrustedService};
 
 use crate::compiler::get_compiler_version;
 use crate::dump;
@@ -304,6 +304,47 @@ pub fn dump_v2(fname: &str, encoded_buf: Bytes) {
                     }
                 }
             }
+        }
+    }
+    if policy.has_trusted_services() {
+        dump::print_section_hdr("TRUSTED SERVICES");
+        for (i, ts_rdr) in policy.get_trusted_services().unwrap().iter().enumerate() {
+            // Decode via the shared TryFrom so the display shares the VS's decode path.
+            match TrustedService::try_from(ts_rdr) {
+                Ok(ts) => {
+                    let expiration = if ts.expiration_seconds == 0 {
+                        "0 (runtime default)".to_string()
+                    } else {
+                        format!("{}s", ts.expiration_seconds)
+                    };
+                    println!(
+                        "{} {}  expiration: {}",
+                        format!("{:02}", i + 1).dimmed(),
+                        ts.service_id.yellow(),
+                        expiration.yellow()
+                    );
+                    for m in &ts.returns_attrs {
+                        println!(
+                            "         {} {} -> {}",
+                            format!("{}", "󰞘").dimmed(),
+                            m.service_attr_key.yellow(),
+                            m.zpr_attr_spec.green()
+                        );
+                    }
+                    if !ts.identity_attrs.is_empty() {
+                        println!("       identity: {}", ts.identity_attrs.join(", ").yellow());
+                    }
+                }
+                Err(e) => {
+                    println!(
+                        "{} {} {}",
+                        format!("{:02}", i + 1).dimmed(),
+                        "(invalid)".red(),
+                        format!("{}", e).red()
+                    );
+                }
+            }
+            println!();
         }
     }
 }

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 use crate::errors::CompilationError;
 use crate::protocols::{PortSpec, Protocol};
 use crate::ptypes::Signal;
-use zpr::policy_types::{Attribute, ServiceType};
+use zpr::policy_types::{AttrMapping, Attribute, ServiceType, TrustedService};
 
 /// A service oriented view of the network.
 #[derive(Debug, Clone, Default)]
@@ -33,8 +33,7 @@ pub struct FabricService {
     pub service_type: ServiceType,
     pub certificate: Option<Vec<u8>>, // Certificate for this (trusted) service
     pub client_service_name: Option<String>, // For an AUTH service, the name of the optional client service.
-    pub returns_attrs: Option<HashMap<String, Attribute>>, // list of attribute keys (with domains) -- only for trusted services
-    pub identity_attrs: Option<Vec<String>>, // list of attribute keys (with domains) -- only for trusted services
+    pub trusted_service: Option<TrustedService>, // Shared metadata record -- only for trusted services
 }
 
 #[derive(Debug, Clone)]
@@ -247,16 +246,24 @@ impl Fabric {
     }
 
     /// You must add client services associated with the trusted service before adding a trusted service.
+    ///
+    /// `protocol` is `None` for a `file` service (which has no network endpoints); the policy
+    /// writer turns that into an empty endpoint list. `client_service_name`/`certificate` are
+    /// `None` for services without an adapter-facing component or cert. Builds the shared
+    /// [`TrustedService`] metadata record from the ordered `returns_attrs`, `identity_attrs`,
+    /// and `expiration_seconds`.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_trusted_service(
         &mut self,
         id: &str,
-        protocol: &Protocol,
+        protocol: Option<&Protocol>,
         api: &str,
         provider_attrs: &[Attribute],
         certificate: Option<Vec<u8>>,
-        client_service_name: &str,
-        returns_attrs: Option<HashMap<String, Attribute>>,
-        identity_attrs: Option<Vec<String>>,
+        client_service_name: Option<&str>,
+        returns_attrs: Vec<AttrMapping>,
+        identity_attrs: Vec<String>,
+        expiration_seconds: u32,
     ) -> Result<(), CompilationError> {
         for s in &self.services {
             if s.config_id == id {
@@ -269,14 +276,18 @@ impl Fabric {
         let fs = FabricService {
             config_id: id.to_string(),
             fabric_id: id.to_string(),
-            protocol: Some(protocol.clone()),
+            protocol: protocol.cloned(),
             provider_attrs: provider_attrs.to_vec(),
             client_policies: Vec::new(),
             service_type: ServiceType::Trusted(api.to_string()),
             certificate,
-            client_service_name: Some(client_service_name.to_string()),
-            returns_attrs: returns_attrs,
-            identity_attrs: identity_attrs,
+            client_service_name: client_service_name.map(|s| s.to_string()),
+            trusted_service: Some(TrustedService {
+                service_id: id.to_string(),
+                expiration_seconds,
+                returns_attrs,
+                identity_attrs,
+            }),
         };
         self.services.push(fs);
         Ok(())
@@ -342,8 +353,7 @@ impl Fabric {
             service_type: stype,
             certificate: None,
             client_service_name: None,
-            returns_attrs: None,
-            identity_attrs: None,
+            trusted_service: None,
         };
         self.services.push(fs);
         Ok(fabric_id)
@@ -390,8 +400,7 @@ impl Fabric {
             service_type: ServiceType::BuiltIn,
             certificate: None,
             client_service_name: None,
-            returns_attrs: None,
-            identity_attrs: None,
+            trusted_service: None,
         };
         self.services.push(fs);
         Ok(fabric_id)

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -22,7 +22,6 @@ pub struct Fabric {
     pub links: Vec<FabricLink>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct FabricService {
     pub config_id: String, // Service name as specified in configuration and ZPL.
@@ -34,6 +33,20 @@ pub struct FabricService {
     pub certificate: Option<Vec<u8>>, // Certificate for this (trusted) service
     pub client_service_name: Option<String>, // For an AUTH service, the name of the optional client service.
     pub trusted_service: Option<TrustedService>, // Shared metadata record -- only for trusted services
+}
+
+/// Parameters for [`Fabric::add_trusted_service`].
+#[derive(Debug, Clone, Default)]
+pub struct TrustedServiceSpec {
+    pub id: String,
+    pub api: String,
+    pub protocol: Option<Protocol>,
+    pub provider_attrs: Vec<Attribute>,
+    pub certificate: Option<Vec<u8>>,
+    pub client_service_name: Option<String>,
+    pub returns_attrs: Vec<AttrMapping>,
+    pub identity_attrs: Vec<String>,
+    pub expiration_seconds: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -245,48 +258,38 @@ impl Fabric {
         &self.bootstrap_records
     }
 
-    /// You must add client services associated with the trusted service before adding a trusted service.
+    /// You must add client services associated with the trusted service before
+    /// adding a trusted service.
     ///
-    /// `protocol` is `None` for a `file` service (which has no network endpoints); the policy
-    /// writer turns that into an empty endpoint list. `client_service_name`/`certificate` are
-    /// `None` for services without an adapter-facing component or cert. Builds the shared
-    /// [`TrustedService`] metadata record from the ordered `returns_attrs`, `identity_attrs`,
-    /// and `expiration_seconds`.
-    #[allow(clippy::too_many_arguments)]
+    /// Builds the shared [`TrustedService`] metadata record from the ordered
+    /// `returns_attrs`, `identity_attrs`, and `expiration_seconds` (see [TrustedServiceSpec]).
     pub fn add_trusted_service(
         &mut self,
-        id: &str,
-        protocol: Option<&Protocol>,
-        api: &str,
-        provider_attrs: &[Attribute],
-        certificate: Option<Vec<u8>>,
-        client_service_name: Option<&str>,
-        returns_attrs: Vec<AttrMapping>,
-        identity_attrs: Vec<String>,
-        expiration_seconds: u32,
+        spec: TrustedServiceSpec,
     ) -> Result<(), CompilationError> {
         for s in &self.services {
-            if s.config_id == id {
+            if s.config_id == spec.id {
                 return Err(CompilationError::BuildError(format!(
-                    "cannot add duplicate trusted service: already exists: {id}"
+                    "cannot add duplicate trusted service: already exists: {}",
+                    spec.id
                 )));
             }
         }
 
         let fs = FabricService {
-            config_id: id.to_string(),
-            fabric_id: id.to_string(),
-            protocol: protocol.cloned(),
-            provider_attrs: provider_attrs.to_vec(),
+            config_id: spec.id.clone(),
+            fabric_id: spec.id.clone(),
+            protocol: spec.protocol,
+            provider_attrs: spec.provider_attrs,
             client_policies: Vec::new(),
-            service_type: ServiceType::Trusted(api.to_string()),
-            certificate,
-            client_service_name: client_service_name.map(|s| s.to_string()),
+            service_type: ServiceType::Trusted(spec.api),
+            certificate: spec.certificate,
+            client_service_name: spec.client_service_name,
             trusted_service: Some(TrustedService {
-                service_id: id.to_string(),
-                expiration_seconds,
-                returns_attrs,
-                identity_attrs,
+                service_id: spec.id,
+                expiration_seconds: spec.expiration_seconds,
+                returns_attrs: spec.returns_attrs,
+                identity_attrs: spec.identity_attrs,
             }),
         };
         self.services.push(fs);

--- a/src/policybinaryv2.rs
+++ b/src/policybinaryv2.rs
@@ -12,12 +12,12 @@ use crate::policywriter::{PolicyContainer, PolicyWriter};
 use crate::protocols::{IcmpFlowType, PortSpec, Protocol, ProtocolDetails};
 use crate::ptypes::Signal;
 
+use zpr::policy_types::TrustedService;
 use zpr::policy_types::write_attributes;
 use zpr::policy_types::{AttrExp, AttrOp, Attribute, PFlags};
 use zpr::policy_types::{JoinPolicy, Scope, ScopeFlag};
 use zpr::policy_types::{NetAddr, Peering};
 use zpr::policy_types::{Service, ServiceType}; // TODO: remove refs to fabric
-use zpr::policy_types::TrustedService;
 
 #[derive(Default)]
 pub struct PolicyBinaryV2 {

--- a/src/policybinaryv2.rs
+++ b/src/policybinaryv2.rs
@@ -8,7 +8,7 @@ use zpr::write_to::WriteTo;
 
 use crate::compiler::get_compiler_version;
 use crate::errors::CompilationError;
-use crate::policywriter::{PolicyContainer, PolicyWriter, TSType};
+use crate::policywriter::{PolicyContainer, PolicyWriter};
 use crate::protocols::{IcmpFlowType, PortSpec, Protocol, ProtocolDetails};
 use crate::ptypes::Signal;
 
@@ -17,6 +17,7 @@ use zpr::policy_types::{AttrExp, AttrOp, Attribute, PFlags};
 use zpr::policy_types::{JoinPolicy, Scope, ScopeFlag};
 use zpr::policy_types::{NetAddr, Peering};
 use zpr::policy_types::{Service, ServiceType}; // TODO: remove refs to fabric
+use zpr::policy_types::TrustedService;
 
 #[derive(Default)]
 pub struct PolicyBinaryV2 {
@@ -27,6 +28,7 @@ pub struct PolicyBinaryV2 {
     bootstrap_keys: Vec<BootstrapKey>,
     join_policies: JPBuilder,
     topology: Vec<Peering>,
+    trusted_services: Vec<TrustedService>,
 }
 
 #[allow(dead_code)]
@@ -259,14 +261,18 @@ impl PolicyWriter for PolicyBinaryV2 {
         svc_attrs: &[Attribute],
         svc_id: &str,
         stype: &ServiceType,
-        endpoint: &Protocol,
+        endpoint: Option<&Protocol>,
         flags: Option<PFlags>,
     ) {
         // assumption: service type is set.
         if stype == &ServiceType::Undefined {
             panic!("service cannot have undefined type");
         }
-        let endpoints = new_scope_from_protocol(endpoint);
+        // No protocol -> no endpoints (a `file` trusted service).
+        let endpoints = match endpoint {
+            Some(prot) => new_scope_from_protocol(prot),
+            None => Vec::new(),
+        };
         let service = Service {
             id: svc_id.into(),
             endpoints,
@@ -349,16 +355,8 @@ impl PolicyWriter for PolicyBinaryV2 {
         self.topology.push(peering);
     }
 
-    fn write_trusted_service(
-        &mut self,
-        _svc_id: &str,
-        _ts_type: TSType,
-        _query_uri: Option<&str>,
-        _validate_uri: Option<&str>,
-        _returns_attrs: Option<&HashMap<String, Attribute>>,
-        _identity_attrs: Option<&Vec<String>>,
-    ) {
-        // nop
+    fn write_trusted_service_record(&mut self, ts: TrustedService) {
+        self.trusted_services.push(ts);
     }
 
     fn print_stats(&self) {
@@ -461,10 +459,22 @@ impl PolicyWriter for PolicyBinaryV2 {
         }
 
         if !self.topology.is_empty() {
-            let mut topl = policy.init_topology(self.topology.len() as u32);
+            let mut topl = policy.reborrow().init_topology(self.topology.len() as u32);
             for (i, peering) in self.topology.iter().enumerate() {
                 let mut p_builder = topl.reborrow().get(i as u32);
                 peering.write_to(&mut p_builder);
+            }
+        }
+
+        // Emit the shared trusted-service records, sorted by service_id for deterministic output.
+        if !self.trusted_services.is_empty() {
+            let mut ts_records = self.trusted_services.clone();
+            ts_records.sort_by(|a, b| a.service_id.cmp(&b.service_id));
+            let mut ts_list = policy
+                .reborrow()
+                .init_trusted_services(ts_records.len() as u32);
+            for (i, ts) in ts_records.iter().enumerate() {
+                ts.write_to(&mut ts_list.reborrow().get(i as u32));
             }
         }
 

--- a/src/policybuilder.rs
+++ b/src/policybuilder.rs
@@ -130,11 +130,13 @@ impl<T: PolicyWriter> PolicyBuilder<T> {
         Ok(())
     }
 
-    /// Emit one shared `TrustedService` metadata record per woven `file` or `validation/2`
-    /// service. There is no record for the builtin `default` service (it is not a fabric
-    /// `Trusted` service) nor for the validation/2 adapter-facing authentication service (it is
-    /// a `ServiceType::Authentication` service). Validation/2 network join/communication policies
-    /// are still emitted through the normal fabric paths (`set_connects`/`set_policies`).
+    /// Emit one shared `TrustedService` metadata record per woven `file` or
+    /// `validation/2` service. There is no record for the builtin `default`
+    /// service (it is not a fabric `Trusted` service) nor for the validation/2
+    /// adapter-facing authentication service (it is tied to its vs-facing
+    /// `validation/2` service which does get a record). Validation/2 network
+    /// join/communication policies are also emitted through the normal fabric
+    /// paths (`set_connects`/`set_policies`).
     fn set_trusted_service_records(
         &mut self,
         fabric: &Fabric,

--- a/src/policybuilder.rs
+++ b/src/policybuilder.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::context::CompilationCtx;
 use crate::errors::CompilationError;
 use crate::fabric::Fabric;
-use crate::policywriter::{PolicyWriter, TSType};
+use crate::policywriter::PolicyWriter;
 use crate::protocols::{PortSpec, Protocol};
 use crate::zpl;
 use zpr::policy_types::{Attribute, PFlags, ServiceType};
@@ -108,7 +108,7 @@ impl<T: PolicyWriter> PolicyBuilder<T> {
         self.set_topology(fabric)?;
         self.set_default_auth(fabric, ctx)?;
         self.set_bootstrap(fabric, ctx)?;
-        self.set_auth_services(fabric, ctx)?;
+        self.set_trusted_service_records(fabric, ctx)?;
 
         if self.verbose {
             self.policy_writer.print_stats();
@@ -130,84 +130,40 @@ impl<T: PolicyWriter> PolicyBuilder<T> {
         Ok(())
     }
 
-    fn set_auth_services(
+    /// Emit one shared `TrustedService` metadata record per woven `file` or `validation/2`
+    /// service. There is no record for the builtin `default` service (it is not a fabric
+    /// `Trusted` service) nor for the validation/2 adapter-facing authentication service (it is
+    /// a `ServiceType::Authentication` service). Validation/2 network join/communication policies
+    /// are still emitted through the normal fabric paths (`set_connects`/`set_policies`).
+    fn set_trusted_service_records(
         &mut self,
         fabric: &Fabric,
         _ctx: &CompilationCtx,
     ) -> Result<(), CompilationError> {
         for svc in &fabric.services {
-            let apiname: String = match svc.service_type {
-                ServiceType::Trusted(ref t) => t.clone(),
-                _ => {
-                    continue; // not a trusted service
-                }
-            };
+            match svc.service_type {
+                ServiceType::Trusted(_) => {}
+                _ => continue, // not a trusted service
+            }
 
-            if apiname != zpl::TS_API_V2 {
-                return Err(CompilationError::ConfigError(format!(
-                    "trusted service {}: only 'validation/2' api supported, not '{}'",
-                    svc.config_id, apiname
+            let record = svc.trusted_service.as_ref().ok_or_else(|| {
+                CompilationError::BuildError(format!(
+                    "trusted service {} is missing its metadata record",
+                    svc.fabric_id
+                ))
+            })?;
+
+            // Trusted-service IDs are restricted, so the fabric id is used unchanged for both the
+            // join-policy `Service.id` and `TrustedService.service_id`; they must be identical.
+            if svc.fabric_id != record.service_id {
+                return Err(CompilationError::BuildError(format!(
+                    "trusted service fabric id '{}' does not match record service_id '{}'",
+                    svc.fabric_id, record.service_id
                 )));
             }
 
-            if svc.client_service_name.is_none() {
-                return Err(CompilationError::ConfigError(format!(
-                    "trusted service {}: missing client facing service name",
-                    svc.config_id
-                )));
-            }
-
-            // The trusted service actually has two addresses.
-            // The vs-address which is service named <id>-vs
-            // And the adapter auth address whic is at <id>-<client-service-name>
-
-            // The VS facing service details have been copied out of config.
-
-            let canonical_svc_id = self.get_canonical_service_name(&svc.config_id);
-
-            // pretty sure it is an error if config_id != fabric_id in these cases.
-            // TODO: Not sure why we are using config_id here and not fabric_id.
-            if svc.config_id != svc.fabric_id {
-                panic!(
-                    "logic error - config_id '{}' is not same as fabric id '{}'",
-                    svc.config_id, svc.fabric_id
-                );
-            }
-
-            let (l7p, port) = svc.get_l7protocol_and_port()?;
-            self.policy_writer.write_trusted_service(
-                &canonical_svc_id,
-                TSType::VsAuth,
-                None,                                       // query uri
-                Some(&format!("{}://[::1]:{}", l7p, port)), // validate uri
-                svc.returns_attrs.as_ref(),
-                svc.identity_attrs.as_ref(),
-            );
-
-            // The adapter facing auth service (if present) we register as a new-style "authentication" service.
-            if let Some(asvc) = fabric.get_service(svc.client_service_name.as_ref().unwrap()) {
-                // TODO: Not sure why we are using config_id here and not fabric_id.
-                if asvc.config_id != asvc.fabric_id {
-                    panic!(
-                        "logic error - config_id '{}' is not same as fabric id '{}'",
-                        asvc.config_id, asvc.fabric_id
-                    );
-                }
-                let canonical_asvc_id = self.get_canonical_service_name(&asvc.config_id);
-                let (l7p, port) = asvc.get_l7protocol_and_port()?;
-                self.policy_writer.write_trusted_service(
-                    &canonical_asvc_id,
-                    TSType::ActorAuth,
-                    None, // query uri
-                    Some(&format!("{}://[::1]:{}", l7p, port)),
-                    None, // not set for adapter facing
-                    None, // not set for adapter facing
-                );
-            } else {
-                // Not found. This means that either the service has no adapter facing offering
-                // (ie, it is a query only service). Or the user did not add any ZPL allowing
-                // access -- which is warned about in a previous parsing step.
-            }
+            self.policy_writer
+                .write_trusted_service_record(record.clone());
         }
         Ok(())
     }
@@ -292,17 +248,25 @@ impl<T: PolicyWriter> PolicyBuilder<T> {
                         &svc.provider_attrs,
                         &svc_id,
                         &svc.service_type,
-                        &svc.protocol.as_ref().unwrap(),
+                        Some(svc.protocol.as_ref().expect("service must have a protocol")),
                         flags,
                     )
                 }
 
-                ServiceType::Trusted(_) => {
+                ServiceType::Trusted(ref api) => {
+                    // Only a `file` trusted service may have no protocol; all network-facing
+                    // services must carry one.
+                    if svc.protocol.is_none() && api != zpl::TS_API_FILE {
+                        return Err(CompilationError::BuildError(format!(
+                            "trusted service {} of type '{}' is missing a protocol",
+                            svc.fabric_id, api
+                        )));
+                    }
                     self.policy_writer.write_connect_match_for_provider(
                         &svc.provider_attrs,
                         &svc.fabric_id,
                         &svc.service_type,
-                        &svc.protocol.as_ref().unwrap(),
+                        svc.protocol.as_ref(),
                         None,
                     );
                     if let Some(cert_data) = &svc.certificate {
@@ -333,7 +297,7 @@ impl<T: PolicyWriter> PolicyBuilder<T> {
                 &node.provider_attrs,
                 &svc_id,
                 &ServiceType::Regular,
-                &dummy_prot,
+                Some(&dummy_prot),
                 Some(PFlags::node(true)), // TODO: Not all nodes are VS docks
             );
         }

--- a/src/policywriter.rs
+++ b/src/policywriter.rs
@@ -4,12 +4,7 @@ use std::net::IpAddr;
 use crate::errors::CompilationError;
 use crate::protocols::Protocol;
 use crate::ptypes::Signal;
-use zpr::policy_types::{Attribute, PFlags, ServiceType};
-
-pub enum TSType {
-    VsAuth,    // trusted service <-> visa service
-    ActorAuth, // trusted service <-> adapter
-}
+use zpr::policy_types::{Attribute, PFlags, ServiceType, TrustedService};
 
 /// To support multiple policy output formats, this trait defines the interface for writing policies.
 pub trait PolicyWriter {
@@ -21,13 +16,14 @@ pub trait PolicyWriter {
     fn write_policy_metadata(&mut self, metadata: &str);
     fn write_max_visa_lifetime(&mut self, lifetime: std::time::Duration);
 
+    /// Write a join policy for a service provider. `endpoint` is `None` for services with no
+    /// network endpoints (a `file` trusted service) which yields an empty endpoint list.
     fn write_connect_match_for_provider(
         &mut self,
         svc_attrs: &[Attribute],
         svc_id: &str,
         stype: &ServiceType,
-        //endpoint: &str,
-        endpoint: &Protocol,
+        endpoint: Option<&Protocol>,
         flags: Option<PFlags>,
     );
 
@@ -54,15 +50,8 @@ pub trait PolicyWriter {
         value_table: &HashMap<String, usize>,
     );
 
-    fn write_trusted_service(
-        &mut self,
-        svc_id: &str,
-        ts_type: TSType,
-        query_uri: Option<&str>,
-        validate_uri: Option<&str>,
-        returns_attrs: Option<&HashMap<String, Attribute>>,
-        identity_attrs: Option<&Vec<String>>,
-    );
+    /// Emit one shared `TrustedService` metadata record into the policy's `trustedServices` list.
+    fn write_trusted_service_record(&mut self, ts: TrustedService);
 
     fn write_link(
         &mut self,

--- a/src/weaver.rs
+++ b/src/weaver.rs
@@ -540,13 +540,14 @@ impl Weaver {
                     // TODO: Not sure we are handling the case where ZPL is using prefixes correctly here.
                     let mut matched = false;
                     for ts_name in &trusted_service_names {
-                        let ts_attrs = config.must_get_attr_map(&format!(
+                        let ts_attrs = config.must_get_attr_mappings(&format!(
                             "/trusted_services/{}/attributes",
                             ts_name
                         ));
 
-                        // "a" is the attribute referenced in the ZPL, so this will turn up on the RIGHT side of the map.
-                        // The left side (the strings) are the names of the raw attributes returned by the service.
+                        // "a" is the attribute referenced in the ZPL, so it appears on the RHS
+                        // (the decoded `mapping.attr`) of a return mapping. The LHS
+                        // (`service_attr_key`) is the raw name the service reports.
 
                         // As we search we need to consider that a tuple type attribute could match
                         // either the service plain key eg, "user.role" or the service multi-value key, eg, "user.role{}".
@@ -557,14 +558,13 @@ impl Weaver {
                             None
                         };
 
-                        let found = ts_attrs.iter().find(|(_k, v)| {
-                            v.zplc_key() == search_str
+                        let found = ts_attrs.iter().find(|m| {
+                            m.attr.zplc_key() == search_str
                                 || alt_search_str.is_some()
-                                    && &v.zplc_key() == alt_search_str.as_ref().unwrap()
+                                    && &m.attr.zplc_key() == alt_search_str.as_ref().unwrap()
                         });
 
-                        //if ts_attrs.contains(&search_name) {
-                        if let Some((_svcname, attr_spec)) = found {
+                        if let Some(mapping) = found {
                             if matched {
                                 return Err(CompilationError::ConfigError(format!(
                                     "attribute {} found in multiple trusted services",
@@ -573,7 +573,7 @@ impl Weaver {
                             }
                             let mut new_attr = zpl_attr.clone();
                             // If the service indicates that this attribute is multi-valued then we keep that info.
-                            if attr_spec.is_multi_valued() {
+                            if mapping.attr.is_multi_valued() {
                                 new_attr.set_multi_valued()?;
                             }
                             resolved_attrs.push(new_attr);
@@ -1015,6 +1015,16 @@ impl Weaver {
                     continue;
                 }
                 checked_services.insert(ts_name.clone());
+
+                // A `file` service is offered by the Visa Service itself and has no provider
+                // attributes to resolve.
+                let ts_api = config
+                    .must_get(&format!("/trusted_services/{ts_name}/api"))
+                    .to_string();
+                if ts_api == zpl::TS_API_FILE {
+                    continue;
+                }
+
                 let ts_provider_attrs =
                     match config.get(&format!("/trusted_services/{ts_name}/provider")) {
                         Some(ConfigItem::AttrList(attrs)) => vec_to_attributes(&attrs)?,
@@ -1043,9 +1053,11 @@ impl Weaver {
     ) -> Result<(), CompilationError> {
         self.resolve_trusted_service_providers(config, ctx)?;
 
-        // Copy the used trusted service names into a stand alone vector to avoid
-        // holding an immutable ref to self in the following loop.
-        let used_trusted_service_names = self.wctx.used_trusted_services.clone();
+        // Copy the used trusted service names into a stand alone, sorted vector: it avoids
+        // holding an immutable ref to self in the loop below and gives deterministic weave order.
+        let mut used_trusted_service_names: Vec<String> =
+            self.wctx.used_trusted_services.iter().cloned().collect();
+        used_trusted_service_names.sort();
 
         for ts_name in used_trusted_service_names {
             if ts_name == zpl::DEFAULT_TRUSTED_SERVICE_ID {
@@ -1055,6 +1067,43 @@ impl Weaver {
             let ts_api = config
                 .must_get(&format!("/trusted_services/{ts_name}/api"))
                 .to_string();
+
+            // Return mappings and expiration are common to every trusted-service API.
+            let ts_returns_attrs =
+                config.must_get_attr_mappings(&format!("/trusted_services/{ts_name}/attributes"));
+            let expiration_seconds =
+                config.must_get_u32(&format!("/trusted_services/{ts_name}/expiration_seconds"));
+
+            // A `file` service has no network presence (no client/vs interface, provider, cert, or
+            // protocol). It is offered by the Visa Service (vs.zpr) itself, so it lands in the VS
+            // join policy via the ServiceType::Trusted path with an empty endpoint list, and gets
+            // no communication policy.
+            if ts_api == zpl::TS_API_FILE {
+                let vs_cn_attr = Attribute::tuple(zpl::KATTR_CN)
+                    .single()
+                    .value(zpl::VISA_SERVICE_CN)
+                    .build()?;
+                self.fabric
+                    .add_trusted_service(
+                        &ts_name,
+                        None,
+                        &ts_api,
+                        &[vs_cn_attr],
+                        None,
+                        None,
+                        ts_returns_attrs,
+                        Vec::new(),
+                        expiration_seconds,
+                    )
+                    .map_err(|e| {
+                        CompilationError::ConfigError(format!(
+                            "error adding trusted service: {}",
+                            e
+                        ))
+                    })?;
+                continue;
+            }
+
             let client_svc = config
                 .must_get(&format!("/trusted_services/{ts_name}/client_service"))
                 .to_string();
@@ -1086,21 +1135,11 @@ impl Weaver {
             let vs_svc_protocol =
                 self.check_ts_components(config, ctx, &ts_name, &client_svc, &vs_svc, &ts_api)?;
 
-            // The trusted service must return some attributes, and may return some identity attributes.
-            let ts_returns_attrs =
-                match config.get(&format!("/trusted_services/{ts_name}/attributes")) {
-                    Some(ConfigItem::AttributeMap(map)) => map,
-                    _ => {
-                        return Err(CompilationError::ConfigError(format!(
-                            "trusted service {} missing return attributes",
-                            ts_name
-                        )));
-                    }
-                };
+            // The trusted service may return some identity attributes.
             let ts_identity_attrs =
                 match config.get(&format!("/trusted_services/{ts_name}/id_attributes")) {
-                    Some(ConfigItem::KeySet(attrs)) => Some(attrs),
-                    _ => None,
+                    Some(ConfigItem::KeySet(attrs)) => attrs,
+                    _ => Vec::new(),
                 };
 
             if vs_svc_protocol.is_none() {
@@ -1112,13 +1151,14 @@ impl Weaver {
             self.fabric
                 .add_trusted_service(
                     &ts_name,
-                    &vs_svc_protocol.unwrap(),
+                    Some(&vs_svc_protocol.unwrap()),
                     &ts_api,
                     &ts_provider_attrs,
                     ts_cert,
-                    &client_svc,
-                    Some(ts_returns_attrs),
+                    Some(&client_svc),
+                    ts_returns_attrs,
                     ts_identity_attrs,
+                    expiration_seconds,
                 )
                 .map_err(|e| {
                     CompilationError::ConfigError(format!("error adding trusted service: {}", e))
@@ -1519,11 +1559,20 @@ mod test {
 
         let fsvc = &w.fabric.services[0];
         assert_eq!(fsvc.fabric_id, "bas");
-        let return_attrs = fsvc.returns_attrs.as_ref().unwrap();
+        let ts = fsvc.trusted_service.as_ref().unwrap();
+        let return_attrs = &ts.returns_attrs;
         assert_eq!(return_attrs.len(), 2);
-        assert!(return_attrs["id"].to_schema_string() == "user.id");
-        assert!(return_attrs["email"].to_schema_string() == "user.email");
-        let id_attrs = fsvc.identity_attrs.as_ref().unwrap();
+        let spec = |k: &str| {
+            return_attrs
+                .iter()
+                .find(|m| m.service_attr_key == k)
+                .unwrap()
+                .attr
+                .to_schema_string()
+        };
+        assert_eq!(spec("id"), "user.id");
+        assert_eq!(spec("email"), "user.email");
+        let id_attrs = &ts.identity_attrs;
         assert_eq!(id_attrs.len(), 1);
         assert!(id_attrs.contains(&String::from("id")));
     }
@@ -1561,5 +1610,110 @@ mod test {
                 .used_trusted_services
                 .contains(zpl::DEFAULT_TRUSTED_SERVICE_ID)
         );
+    }
+
+    #[test]
+    fn test_file_trusted_service_used_only() {
+        // Two file services; only one is referenced by the (simulated) ZPL.
+        let cfg = r#"
+        [nodes.n0]
+        zpr_address = "fd5a:5052:90de::1"
+        provider = [["device.zpr.adapter.cn", "fee"]]
+
+        [trusted_services.used_fs]
+        api = "file"
+        returns_attributes = ["a -> user.usedattr"]
+
+        [trusted_services.unused_fs]
+        api = "file"
+        returns_attributes = ["b -> user.unusedattr"]
+        "#;
+        let ctx = CompilationCtx::default();
+        let config = ConfigApi::new_from_toml_content(cfg, &env::temp_dir(), &ctx)
+            .expect("failed to parse config");
+
+        let mut w = Weaver::new(WeavingContext::default());
+
+        // Referencing user.usedattr marks only used_fs as in-use.
+        let attr = Attribute::tuple("user.usedattr")
+            .single()
+            .value("x")
+            .build()
+            .unwrap();
+        let resolved = w
+            .resolve_attributes(&[attr], &config)
+            .expect("attr should resolve");
+        assert_eq!(resolved.len(), 1);
+        assert!(w.wctx.used_trusted_services.contains("used_fs"));
+        assert!(!w.wctx.used_trusted_services.contains("unused_fs"));
+
+        // Only the used file service is woven into the fabric; the unused one is dropped.
+        w.add_trusted_services(&config, &ctx)
+            .expect("add_trusted_services");
+        let trusted: Vec<&str> = w
+            .fabric
+            .services
+            .iter()
+            .filter(|s| matches!(s.service_type, ServiceType::Trusted(_)))
+            .map(|s| s.fabric_id.as_str())
+            .collect();
+        assert_eq!(trusted, vec!["used_fs"]);
+    }
+
+    #[test]
+    fn test_trusted_service_transitive_use() {
+        // `outer` is referenced directly; its provider attribute is vouched for by `inner`,
+        // so `inner` must be discovered transitively and woven too.
+        let cfg = r#"
+        [nodes.n0]
+        zpr_address = "fd5a:5052:90de::1"
+        provider = [["device.zpr.adapter.cn", "fee"]]
+
+        [trusted_services.inner]
+        api = "validation/2"
+        provider = [["device.zpr.adapter.cn", "fee"]]
+        returns_attributes = ["ia -> user.innerattr"]
+
+        [trusted_services.outer]
+        api = "validation/2"
+        provider = [["user.innerattr", "someval"]]
+        returns_attributes = ["oa -> user.outerattr"]
+
+        [services.inner-vs]
+        protocol = "zpr-validation2"
+        port = 3999
+
+        [services.outer-vs]
+        protocol = "zpr-validation2"
+        port = 3998
+        "#;
+        let ctx = CompilationCtx::default();
+        let config = ConfigApi::new_from_toml_content(cfg, &env::temp_dir(), &ctx)
+            .expect("failed to parse config");
+
+        let mut w = Weaver::new(WeavingContext::default());
+        // Reference an attribute only `outer` provides.
+        let attr = Attribute::tuple("user.outerattr")
+            .single()
+            .value("y")
+            .build()
+            .unwrap();
+        w.resolve_attributes(&[attr], &config)
+            .expect("attr should resolve");
+        assert!(w.wctx.used_trusted_services.contains("outer"));
+        assert!(!w.wctx.used_trusted_services.contains("inner"));
+
+        // Weaving discovers `inner` transitively through `outer`'s provider attribute.
+        w.add_trusted_services(&config, &ctx)
+            .expect("add_trusted_services");
+        let mut trusted: Vec<&str> = w
+            .fabric
+            .services
+            .iter()
+            .filter(|s| matches!(s.service_type, ServiceType::Trusted(_)))
+            .map(|s| s.fabric_id.as_str())
+            .collect();
+        trusted.sort();
+        assert_eq!(trusted, vec!["inner", "outer"]);
     }
 }

--- a/src/weaver.rs
+++ b/src/weaver.rs
@@ -10,7 +10,9 @@ use crate::config_api::{ConfigApi, ConfigItem};
 use crate::context::CompilationCtx;
 use crate::crypto::{digest_as_hex, sha256_of_bytes};
 use crate::errors::CompilationError;
-use crate::fabric::{Fabric, FabricLink, FabricNode, NodeLinkAddr, PLine, SubstrateAddr};
+use crate::fabric::{
+    Fabric, FabricLink, FabricNode, NodeLinkAddr, PLine, SubstrateAddr, TrustedServiceSpec,
+};
 use crate::fabric_util::{squash_attributes, vec_to_attributes, vec_to_attributes_in_domain};
 use crate::protocols::{PortSpec, Protocol, ZPR_OAUTH_RSA, ZPR_VALIDATION_2};
 use crate::ptypes::{AllowClause, Class, ClassFlavor, FPos, Policy};
@@ -1084,17 +1086,14 @@ impl Weaver {
                     .value(zpl::VISA_SERVICE_CN)
                     .build()?;
                 self.fabric
-                    .add_trusted_service(
-                        &ts_name,
-                        None,
-                        &ts_api,
-                        &[vs_cn_attr],
-                        None,
-                        None,
-                        ts_returns_attrs,
-                        Vec::new(),
+                    .add_trusted_service(TrustedServiceSpec {
+                        id: ts_name.clone(),
+                        api: ts_api.clone(),
+                        provider_attrs: vec![vs_cn_attr],
+                        returns_attrs: ts_returns_attrs,
                         expiration_seconds,
-                    )
+                        ..Default::default()
+                    })
                     .map_err(|e| {
                         CompilationError::ConfigError(format!(
                             "error adding trusted service: {}",
@@ -1149,17 +1148,17 @@ impl Weaver {
                 )));
             }
             self.fabric
-                .add_trusted_service(
-                    &ts_name,
-                    Some(&vs_svc_protocol.unwrap()),
-                    &ts_api,
-                    &ts_provider_attrs,
-                    ts_cert,
-                    Some(&client_svc),
-                    ts_returns_attrs,
-                    ts_identity_attrs,
+                .add_trusted_service(TrustedServiceSpec {
+                    id: ts_name.clone(),
+                    api: ts_api.clone(),
+                    protocol: Some(vs_svc_protocol.unwrap()),
+                    provider_attrs: ts_provider_attrs,
+                    certificate: ts_cert,
+                    client_service_name: Some(client_svc),
+                    returns_attrs: ts_returns_attrs,
+                    identity_attrs: ts_identity_attrs,
                     expiration_seconds,
-                )
+                })
                 .map_err(|e| {
                     CompilationError::ConfigError(format!("error adding trusted service: {}", e))
                 })?;

--- a/src/zpl.rs
+++ b/src/zpl.rs
@@ -15,6 +15,7 @@ pub const DEFAULT_TRUSTED_SERVICE_API: &str = TS_API_V1;
 
 pub const TS_API_V1: &str = "validation/1";
 pub const TS_API_V2: &str = "validation/2";
+pub const TS_API_FILE: &str = "file";
 
 pub const ICMP_INTERACION_REQUEST_RESPONSE: &str = "request-response";
 pub const ICMP_INTERACTION_ONESHOT: &str = "oneshot";

--- a/test-data/test-file.zpl
+++ b/test-data/test-file.zpl
@@ -1,0 +1,35 @@
+allow clearance:classified government users to access classified
+services.
+
+
+# test
+define database as a service with user.bas_id:1234.
+define employee as a user with user.bas_id.
+
+allow lazy, color:red employees to access classified databases on tint:sales devices.
+
+allow device.zpr.adapter.cn:  users to access classified services.
+
+
+# FIXME?
+# allow classified services to access database.
+
+# ZPL author must define any auth services and ensure that
+# the service name is present in the configuration.
+
+define AuthService as a service.
+
+// define AuthService as a service with device.zpr.adapter.cn:'bas.zpr.org'
+// consider "define AuthService as a service on devices with cn:'bas.zpr.org'
+
+// ZPL author must explicitly grant access to any authentication
+// services for adapters.
+// Access for the visa service is added by the compiler.
+
+allow zpr.adapter.cn: devices to access AuthService.
+
+# In policy you can define "administrators" in any way you want.
+define NetAdmins as users with device.zpr.adapter.cn:'admin.zpr.org'.
+
+# VisaService is a reserved name.
+allow hair_color:red NetAdmins to access VisaService.

--- a/test-data/test-file.zplc
+++ b/test-data/test-file.zplc
@@ -1,4 +1,4 @@
-# minimal config so that we can test parsing the RFC zpl
+# test the 'file' trusted_servce
 
 [nodes.n0]
 provider = [["device.zpr.adapter.cn", "node.zpr.org"]]

--- a/test-data/test-file.zplc
+++ b/test-data/test-file.zplc
@@ -1,0 +1,75 @@
+# minimal config so that we can test parsing the RFC zpl
+
+[nodes.n0]
+provider = [["device.zpr.adapter.cn", "node.zpr.org"]]
+zpr_address = "fd5a:5052:90de::1"
+
+[trusted_services.bas]
+api = "validation/2"
+client = "AuthService"
+cert_path = "bas-tls.crt"
+returns_attributes = [ 
+  "tint -> device.tint", 
+  "color -> user.color", 
+  "government -> #user.government",
+  "govpc -> #device.government",
+  "clearance -> user.clearance", 
+  "classified -> #service.classified", 
+  "roles -> user.role{}",
+  "bas_id -> user.bas_id" 
+]
+identity_attributes = [ "bas_id" ]
+provider = [[ "device.zpr.adapter.cn", "bas.zpr.org" ]]
+# Will expect to find two service definitions later:
+#    bas-vs and bas-client
+
+[trusted_services.attrfile]
+api = "file"
+returns_attributes = ["hair_color -> user.hair_color", "lazy -> #user.lazy"]
+expiration_seconds = 3600
+
+
+[bootstrap]
+"bas.zpr.org" = "rsa-pub-key.pem"
+
+
+# There are pre-defiend "protocols":
+# zpr-validation2
+# zpr-authrsa
+
+[protocols.http]
+l4protocol = "TCP"
+port = 80
+
+[services.server]
+protocol = "http"
+port = "80, 8080, 9090"
+
+[services.Image-database]
+protocol = "http"
+port = "6000-6100"
+
+[services.database]
+protocol = "http"
+port = "80, 100-150, 444"
+
+
+[services.gateway]
+protocol = "http"
+port = "80, 443, 8080, 8083, 30000-31000"
+
+[services.bas-vs]
+protocol = "zpr-validation2"
+port = 3999
+
+[services.AuthService]
+protocol = "zpr-oauthrsa"
+port = 4444
+
+
+# BAS has two access points:
+# - one for adapters
+# - one for visa services
+#
+# Policy needs to allow adapters to access the adapter port
+# and must allow visa service to access the vs port

--- a/tests/zpl-test.rs
+++ b/tests/zpl-test.rs
@@ -1,9 +1,12 @@
 use bytes::Bytes;
 use std::env;
+use std::io::Cursor;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zplc::compilation::{CompilationBuilder, OutputFormat};
 use zplc::dumpv2::dump_v2;
+use zpr::policy::v1 as policy_capnp;
+use zpr::policy_types::TrustedService;
 
 fn get_zpl_dir() -> PathBuf {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -238,4 +241,207 @@ fn can_compile_misc_test_policies() {
             }
         }
     }
+}
+
+// ---- issue #138: `file` trusted services — end-to-end + regression ----
+
+/// Compile `<stem>.zpl` (with its companion `<stem>.zplc`) to a V2 policy and return the inner
+/// policy bytes (already unwrapped from the container).
+fn compile_policy_bytes(stem: &str, temp: &TempDir) -> Vec<u8> {
+    let path = get_zpl_dir().join(format!("{stem}.zpl"));
+    let cb = CompilationBuilder::new(path)
+        .output_format(OutputFormat::V2)
+        .output_directory(&temp.path);
+    let mut comp = cb.build();
+    comp.compile()
+        .unwrap_or_else(|e| panic!("failed to compile {stem}.zpl: {e}"));
+    let encoded = std::fs::read(&comp.output_file).expect("read binary policy");
+    let container_rdr = capnp::serialize::read_message(
+        &mut Cursor::new(encoded),
+        capnp::message::ReaderOptions::new(),
+    )
+    .expect("decode container");
+    let container = container_rdr
+        .get_root::<policy_capnp::policy_container::Reader>()
+        .expect("container root");
+    container.get_policy().expect("policy bytes").to_vec()
+}
+
+/// Total endpoints across every join-policy Service with the given id, asserting each such
+/// Service is `Trusted(expected_api)`.
+fn trusted_service_endpoint_count(policy: &policy_capnp::policy::Reader, id: &str, expected_api: &str) -> usize {
+    let mut count = 0usize;
+    for jp in policy.get_join_policies().unwrap().iter() {
+        let provides = match jp.get_provides() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        for s in provides.iter() {
+            if s.get_id().unwrap().to_str().unwrap() == id {
+                match s.get_kind().which().unwrap() {
+                    policy_capnp::service::kind::Which::Trusted(n) => {
+                        assert_eq!(n.unwrap().to_str().unwrap(), expected_api);
+                    }
+                    _ => panic!("service {id} must be Trusted({expected_api})"),
+                }
+                count += s.get_endpoints().unwrap().len() as usize;
+            }
+        }
+    }
+    count
+}
+
+fn decode_records(policy: &policy_capnp::policy::Reader) -> Vec<TrustedService> {
+    policy
+        .get_trusted_services()
+        .unwrap()
+        .iter()
+        .map(|r| TrustedService::try_from(r).expect("decode trusted service record"))
+        .collect()
+}
+
+fn mappings(ts: &TrustedService) -> Vec<(&str, &str)> {
+    ts.returns_attrs
+        .iter()
+        .map(|m| (m.service_attr_key.as_str(), m.zpr_attr_spec.as_str()))
+        .collect()
+}
+
+#[test]
+fn test_file_trusted_service_end_to_end() {
+    let temp = TempDir::new("file-e2e");
+    let pbytes = compile_policy_bytes("test-file", &temp);
+    let rdr = capnp::serialize::read_message(
+        &mut Cursor::new(pbytes.as_slice()),
+        capnp::message::ReaderOptions::new(),
+    )
+    .unwrap();
+    let policy = rdr.get_root::<policy_capnp::policy::Reader>().unwrap();
+
+    // --- trustedServices: deterministic order, bas + attrfile once each ---
+    assert!(policy.has_trusted_services(), "policy must have trustedServices");
+    let records = decode_records(&policy);
+    let ids: Vec<&str> = records.iter().map(|r| r.service_id.as_str()).collect();
+    assert_eq!(ids, vec!["attrfile", "bas"]);
+
+    // attrfile: expiration 3600, TOML-ordered mappings, empty identity.
+    let attrfile = records.iter().find(|r| r.service_id == "attrfile").unwrap();
+    assert_eq!(attrfile.expiration_seconds, 3600);
+    assert!(attrfile.identity_attrs.is_empty());
+    assert_eq!(
+        mappings(attrfile),
+        vec![("hair_color", "user.hair_color"), ("lazy", "#user.lazy")]
+    );
+
+    // bas validation/2 record retained (default expiration + identity preserved).
+    let bas = records.iter().find(|r| r.service_id == "bas").unwrap();
+    assert_eq!(bas.expiration_seconds, 0);
+    assert_eq!(bas.identity_attrs, vec!["bas_id".to_string()]);
+
+    // --- attrfile join Service: Trusted("file"), zero endpoints, selected by cn = vs.zpr ---
+    let mut attrfile_svc_found = false;
+    for jp in policy.get_join_policies().unwrap().iter() {
+        let provides = match jp.get_provides() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let svc = match provides
+            .iter()
+            .find(|s| s.get_id().unwrap().to_str().unwrap() == "attrfile")
+        {
+            Some(s) => s,
+            None => continue,
+        };
+        attrfile_svc_found = true;
+
+        // The join policy is selected by exactly device.zpr.adapter.cn EQ vs.zpr.
+        let match_exprs = jp.get_match().unwrap();
+        assert_eq!(match_exprs.len(), 1);
+        let e = match_exprs.get(0);
+        assert_eq!(e.get_key().unwrap().to_str().unwrap(), "device.zpr.adapter.cn");
+        assert!(matches!(e.get_op().unwrap(), policy_capnp::AttrOp::Eq));
+        let vals: Vec<&str> = e
+            .get_value()
+            .unwrap()
+            .iter()
+            .map(|v| v.unwrap().to_str().unwrap())
+            .collect();
+        assert_eq!(vals, vec!["vs.zpr"]);
+
+        // The service itself is Trusted("file") with zero endpoints.
+        match svc.get_kind().which().unwrap() {
+            policy_capnp::service::kind::Which::Trusted(n) => {
+                assert_eq!(n.unwrap().to_str().unwrap(), "file")
+            }
+            _ => panic!("attrfile must be Trusted(file)"),
+        }
+        assert_eq!(
+            svc.get_endpoints().unwrap().len(),
+            0,
+            "file service must have zero endpoints"
+        );
+    }
+    assert!(attrfile_svc_found, "attrfile join Service not found");
+
+    // --- no communication policy for the file service ---
+    if policy.has_com_policies() {
+        for cp in policy.get_com_policies().unwrap().iter() {
+            assert_ne!(
+                cp.get_service_id().unwrap().to_str().unwrap(),
+                "attrfile",
+                "file service must have no communication policy"
+            );
+        }
+    }
+
+    // --- validation/2 (bas) service unchanged: retains its real endpoint ---
+    assert!(
+        trusted_service_endpoint_count(&policy, "bas", "validation/2") > 0,
+        "validation/2 service must retain its endpoint"
+    );
+}
+
+#[test]
+fn test_validation2_regression() {
+    // test-bas is validation/2-only; the sole new artifact is the `bas` trustedServices record.
+    // Its join/communication policies must be unchanged by the feature.
+    let temp = TempDir::new("val2-regression");
+    let pbytes = compile_policy_bytes("test-bas", &temp);
+    let rdr = capnp::serialize::read_message(
+        &mut Cursor::new(pbytes.as_slice()),
+        capnp::message::ReaderOptions::new(),
+    )
+    .unwrap();
+    let policy = rdr.get_root::<policy_capnp::policy::Reader>().unwrap();
+
+    // Exactly one record — the validation/2 `bas` service — with its mappings intact.
+    let records = decode_records(&policy);
+    let ids: Vec<&str> = records.iter().map(|r| r.service_id.as_str()).collect();
+    assert_eq!(ids, vec!["bas"], "only the validation/2 record should be emitted");
+    let bas = &records[0];
+    assert_eq!(bas.expiration_seconds, 0);
+    assert_eq!(bas.identity_attrs, vec!["bas_id".to_string()]);
+    assert_eq!(
+        mappings(bas),
+        vec![
+            ("tint", "device.tint"),
+            ("color", "user.color"),
+            ("government", "#user.government"),
+            ("govpc", "#device.government"),
+            ("clearance", "user.clearance"),
+            ("classified", "#service.classified"),
+            ("roles", "user.role{}"),
+            ("bas_id", "user.bas_id"),
+        ]
+    );
+
+    // Join policy for bas still carries its real validation/2 endpoint.
+    assert!(
+        trusted_service_endpoint_count(&policy, "bas", "validation/2") > 0,
+        "validation/2 endpoint missing"
+    );
+
+    // Communication policies are still emitted (join/comm behavior unchanged).
+    assert!(policy.has_com_policies());
+    assert!(policy.get_com_policies().unwrap().len() > 0);
 }

--- a/tests/zpl-test.rs
+++ b/tests/zpl-test.rs
@@ -269,7 +269,11 @@ fn compile_policy_bytes(stem: &str, temp: &TempDir) -> Vec<u8> {
 
 /// Total endpoints across every join-policy Service with the given id, asserting each such
 /// Service is `Trusted(expected_api)`.
-fn trusted_service_endpoint_count(policy: &policy_capnp::policy::Reader, id: &str, expected_api: &str) -> usize {
+fn trusted_service_endpoint_count(
+    policy: &policy_capnp::policy::Reader,
+    id: &str,
+    expected_api: &str,
+) -> usize {
     let mut count = 0usize;
     for jp in policy.get_join_policies().unwrap().iter() {
         let provides = match jp.get_provides() {
@@ -319,7 +323,10 @@ fn test_file_trusted_service_end_to_end() {
     let policy = rdr.get_root::<policy_capnp::policy::Reader>().unwrap();
 
     // --- trustedServices: deterministic order, bas + attrfile once each ---
-    assert!(policy.has_trusted_services(), "policy must have trustedServices");
+    assert!(
+        policy.has_trusted_services(),
+        "policy must have trustedServices"
+    );
     let records = decode_records(&policy);
     let ids: Vec<&str> = records.iter().map(|r| r.service_id.as_str()).collect();
     assert_eq!(ids, vec!["attrfile", "bas"]);
@@ -358,7 +365,10 @@ fn test_file_trusted_service_end_to_end() {
         let match_exprs = jp.get_match().unwrap();
         assert_eq!(match_exprs.len(), 1);
         let e = match_exprs.get(0);
-        assert_eq!(e.get_key().unwrap().to_str().unwrap(), "device.zpr.adapter.cn");
+        assert_eq!(
+            e.get_key().unwrap().to_str().unwrap(),
+            "device.zpr.adapter.cn"
+        );
         assert!(matches!(e.get_op().unwrap(), policy_capnp::AttrOp::Eq));
         let vals: Vec<&str> = e
             .get_value()
@@ -417,7 +427,11 @@ fn test_validation2_regression() {
     // Exactly one record — the validation/2 `bas` service — with its mappings intact.
     let records = decode_records(&policy);
     let ids: Vec<&str> = records.iter().map(|r| r.service_id.as_str()).collect();
-    assert_eq!(ids, vec!["bas"], "only the validation/2 record should be emitted");
+    assert_eq!(
+        ids,
+        vec!["bas"],
+        "only the validation/2 record should be emitted"
+    );
     let bas = &records[0];
     assert_eq!(bas.expiration_seconds, 0);
     assert_eq!(bas.identity_attrs, vec!["bas_id".to_string()]);


### PR DESCRIPTION
See for reference: https://github.com/org-zpr/zpr-visaservice/issues/248
Implements #138 

This branch primarily adds support for file-backed trusted services:

  - Introduces api = "file" trusted services, which load attributes locally through the Visa Service and have no network endpoints or communication policy.
  - Adds trusted-service metadata to V2 policy binaries, including ordered attribute mappings, identity attributes, and optional expiration.
  - Preserves and refactors existing validation/2 trusted-service behavior using shared types from latest zpr-common -- v0.21.0.
  - Bumps zplc from 0.13.0 to 0.14.0.


